### PR TITLE
CircleCI config for depper.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     docker:
       - image: circleci/golang:1.15
 
-    working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+    working_directory: /go/src/github.com/libraries/depper
 
     steps:
 
@@ -18,7 +18,7 @@ jobs:
           command: echo $GCP_SERVICE_ACCOUNT_JSON | base64 -d > ~/.gcp_service_account.json
 
       - checkout:
-          path: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+          path: /go/src/github.com/libraries/depper
 
       - run:
           name: Clone deployment project
@@ -30,22 +30,22 @@ jobs:
 
       - run:
           name: Build image
-          working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+          working_directory: /go/src/github.com/libraries/depper
           command: ~/deploy/tl-deploy-circleci build_image
 
       - run:
           name: Upload image
-          working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+          working_directory: /go/src/github.com/libraries/depper
           command: ~/deploy/tl-deploy-circleci upload_image
 
       - run:
           name: Tag latest
-          working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+          working_directory: /go/src/github.com/libraries/depper
           command: ~/deploy/tl-deploy-circleci tag_latest
 
       - run:
           name: Deploy worker
-          working_directory: /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}
+          working_directory: /go/src/github.com/libraries/depper
           command: ~/deploy/tl-deploy-circleci rollout libraries-depper
 
 workflows:


### PR DESCRIPTION
Adds a CircleCI config file to build and deploy depper.

It's mostly working but blocked on IAM policy currently: https://app.circleci.com/pipelines/github/librariesio/depper/11/workflows/c2d6916f-f736-4477-9cd0-1d7a0edd94f8/jobs/22

k8s counterpart PR: https://github.com/tidelift/infra/pull/198

https://app.clubhouse.io/tidelift/story/15073/deployable-service-for-depper-package-ingestor