### PR TITLE
Make sure we send good logs to stdout and bad logs to stderr.

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func setupLogger() {
 		FullTimestamp: true,
 	})
 
-	log.AddHook(&writer.Hook{ /
+	log.AddHook(&writer.Hook{
 		Writer: os.Stderr,
 		LogLevels: []log.Level{
 			log.PanicLevel,

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/librariesio/depper/publishers"
 	"github.com/robfig/cron/v3"
 	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/writer"
 )
 
 type Depper struct {
@@ -83,6 +84,23 @@ func (depper *Depper) registerIngestorStream(ingestor ingestors.StreamingIngesto
 func setupLogger() {
 	log.SetFormatter(&log.TextFormatter{
 		FullTimestamp: true,
+	})
+
+	log.AddHook(&writer.Hook{ /
+		Writer: os.Stderr,
+		LogLevels: []log.Level{
+			log.PanicLevel,
+			log.FatalLevel,
+			log.ErrorLevel,
+			log.WarnLevel,
+		},
+	})
+	log.AddHook(&writer.Hook{
+		Writer: os.Stdout,
+		LogLevels: []log.Level{
+			log.InfoLevel,
+			log.DebugLevel,
+		},
 	})
 
 	if os.Getenv("DEBUG") == "1" {


### PR DESCRIPTION
This looks like the official way to fork the logs: https://github.com/sirupsen/logrus/blob/d131c24e23baaa812461202af6d7cfa388e2d292/hooks/writer/README.md#usage

https://app.clubhouse.io/tidelift/story/15442/depper-more-consistent-logging