### PR TITLE
Quickfix for stdout/stderr log forking.

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
@@ -85,6 +86,8 @@ func setupLogger() {
 	log.SetFormatter(&log.TextFormatter{
 		FullTimestamp: true,
 	})
+
+	log.SetOutput(ioutil.Discard) // Send all logs to nowhere by default
 
 	log.AddHook(&writer.Hook{
 		Writer: os.Stderr,

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func setupLogger() {
 		FullTimestamp: true,
 	})
 
-	log.AddHook(&writer.Hook{ /
+	log.AddHook(&writer.Hook{
 		Writer: os.Stderr,
 		LogLevels: []log.Level{
 			log.PanicLevel,

--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func setupLogger() {
 		FullTimestamp: true,
 	})
 
-	// Send error-y logs to stderr
+	// Send error-y logs to stderr and info-y logs to stdout
 	log.SetOutput(ioutil.Discard)
 	log.AddHook(&writer.Hook{
 		Writer: os.Stderr,
@@ -98,7 +98,6 @@ func setupLogger() {
 			log.WarnLevel,
 		},
 	})
-	// Send info-y logs to stdout
 	log.AddHook(&writer.Hook{
 		Writer: os.Stdout,
 		LogLevels: []log.Level{

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/librariesio/depper/publishers"
 	"github.com/robfig/cron/v3"
 	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/writer"
 )
 
 type Depper struct {
@@ -83,6 +84,23 @@ func (depper *Depper) registerIngestorStream(ingestor ingestors.StreamingIngesto
 func setupLogger() {
 	log.SetFormatter(&log.TextFormatter{
 		FullTimestamp: true,
+	})
+
+	log.AddHook(&writer.Hook{ /
+		Writer: os.Stderr,
+		LogLevels: []log.Level{
+			log.PanicLevel,
+			log.FatalLevel,
+			log.ErrorLevel,
+			log.WarnLevel,
+		},
+	})
+	log.AddHook(&writer.Hook{
+		Writer: os.Stdout,
+		LogLevels: []log.Level{
+			log.InfoLevel,
+			log.DebugLevel,
+		},
 	})
 
 	if os.Getenv("DEBUG") == "1" {

--- a/main.go
+++ b/main.go
@@ -87,8 +87,8 @@ func setupLogger() {
 		FullTimestamp: true,
 	})
 
-	log.SetOutput(ioutil.Discard) // Send all logs to nowhere by default
-
+	// Send error-y logs to stderr
+	log.SetOutput(ioutil.Discard)
 	log.AddHook(&writer.Hook{
 		Writer: os.Stderr,
 		LogLevels: []log.Level{
@@ -98,6 +98,7 @@ func setupLogger() {
 			log.WarnLevel,
 		},
 	})
+	// Send info-y logs to stdout
 	log.AddHook(&writer.Hook{
 		Writer: os.Stdout,
 		LogLevels: []log.Level{


### PR DESCRIPTION
One thing I missed from the hooks docs! Fixes this duplicate logging:

![Screen Shot 2021-01-14 at 4 49 44 PM](https://user-images.githubusercontent.com/5054/104653432-9a590b80-5688-11eb-82bf-a6635487d886.png)

https://app.clubhouse.io/tidelift/story/15442/depper-more-consistent-logging