### PR TITLE
Removed logging from ingestors directly

### DIFF
--- a/ingestors/elm.go
+++ b/ingestors/elm.go
@@ -2,12 +2,14 @@ package ingestors
 
 import (
 	"fmt"
-	"github.com/librariesio/depper/data"
-	"github.com/mmcdole/gofeed"
-	"log"
 	"net/url"
 	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/librariesio/depper/data"
+	"github.com/mmcdole/gofeed"
 )
 
 const elmSchedule = "0 */4 * * *"
@@ -39,7 +41,7 @@ func (ingestor *Elm) ingestURL(feedUrl string) []data.PackageVersion {
 	feed, err := fp.ParseURL(feedUrl)
 
 	if err != nil {
-		log.Print(err)
+		log.WithFields(log.Fields{"ingestor": "elm"}).Error(err)
 		return results
 	}
 	for _, item := range feed.Items {

--- a/ingestors/npm.go
+++ b/ingestors/npm.go
@@ -46,7 +46,6 @@ func (ingestor *NPM) Ingest(results chan data.PackageVersion) {
 	if err != nil {
 		log.WithFields(log.Fields{"ingestor": "npm"}).Fatal(err)
 	}
-	log.WithFields(log.Fields{"platform": "npm", "sequence": since}).Info("Depper ingest")
 
 	couchDb := ingestor.couchClient.DB(NPMRegistryDatabase)
 	changes, err := couchDb.Changes(context.Background(), kivik.Options{

--- a/ingestors/rubygems.go
+++ b/ingestors/rubygems.go
@@ -11,9 +11,9 @@ import (
 	"github.com/librariesio/depper/data"
 )
 
-const RubyGemsSchedule = "*/5 * * * *"
-const RubyGemsJustUpdatedURL = "https://rubygems.org/api/v1/activity/just_updated.json"
-const RubyGemsLatestURL = "https://rubygems.org/api/v1/activity/latest.json"
+const rubyGemsSchedule = "*/5 * * * *"
+const rubyGemsJustUpdatedURL = "https://rubygems.org/api/v1/activity/just_updated.json"
+const rubyGemsLatestURL = "https://rubygems.org/api/v1/activity/latest.json"
 
 type RubyGems struct {
 	LatestRun time.Time
@@ -24,14 +24,13 @@ func NewRubyGems() *RubyGems {
 }
 
 func (ingestor *RubyGems) Schedule() string {
-	return RubyGemsSchedule
+	return rubyGemsSchedule
 }
 
 func (ingestor *RubyGems) Ingest() []data.PackageVersion {
-	log.WithFields(log.Fields{"platform": "rubygems"}).Info("Depper ingest")
 	results := append(
-		ingestor.ingestURL(RubyGemsJustUpdatedURL),
-		ingestor.ingestURL(RubyGemsLatestURL)...,
+		ingestor.ingestURL(rubyGemsJustUpdatedURL),
+		ingestor.ingestURL(rubyGemsLatestURL)...,
 	)
 
 	ingestor.LatestRun = time.Now()


### PR DESCRIPTION
Removing ingestion logging in individual ingestors. If we _want_ to do something to log these we can do them at a higher level, but I think for now the logging publisher gets us what we need.