### PR TITLE
Extract redis to service-wide global connection pool.

### DIFF
--- a/ingestors/npm.go
+++ b/ingestors/npm.go
@@ -106,7 +106,7 @@ func (ingestor *NPM) SetLatestSequence(seq string) error {
 	return nil
 }
 
-func (ingestorr *NPM) GetLatestSequence() (string, error) {
+func (ingestor *NPM) GetLatestSequence() (string, error) {
 	val, err := redis.Client.Get(context.Background(), NPMLatestSequenceRedisKey).Result()
 	if err == redis.Nil {
 		return "now", nil

--- a/publishers/sidekiq.go
+++ b/publishers/sidekiq.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/librariesio/depper/data"
 	"github.com/librariesio/depper/redis"
-	_ "github.com/librariesio/depper/redis"
 )
 
 const TTL = 24 * time.Hour

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -2,8 +2,9 @@ package redis
 
 import (
 	"context"
-	"log"
 	"os"
+
+	log "github.com/sirupsen/logrus"
 
 	redis "github.com/go-redis/redis/v8"
 )

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -12,7 +12,7 @@ var Client *redis.Client
 var Nil = redis.Nil
 
 func init() {
-	address := "localhost:6378"
+	address := "localhost:6379"
 	if envVal, envFound := os.LookupEnv("REDISCLOUD_URL"); envFound {
 		address = envVal
 	}

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -1,0 +1,28 @@
+package redis
+
+import (
+	"context"
+	"log"
+	"os"
+
+	redis "github.com/go-redis/redis/v8"
+)
+
+var Client *redis.Client
+var Nil = redis.Nil
+
+func init() {
+	address := "localhost:6378"
+	if envVal, envFound := os.LookupEnv("REDISCLOUD_URL"); envFound {
+		address = envVal
+	}
+
+	Client = redis.NewClient(&redis.Options{
+		Addr:     address,
+		Password: "",
+		DB:       0,
+	})
+	if err := Client.Ping(context.Background()).Err(); err != nil {
+		log.Fatalf("Error connecting to redis: %s", err.Error())
+	}
+}


### PR DESCRIPTION
Extract a `redis` package with a `redis.Client` global variable we can use for all redis-y things in Depper.

We don't need to setup a pool because the redis library already does this by default, with reasonable default settings (10 connections per CPU, by default, etc).