### PR TITLE
Add ingestor for Nuget.

### DIFF
--- a/ingestors/nuget.go
+++ b/ingestors/nuget.go
@@ -1,0 +1,130 @@
+package ingestors
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/librariesio/depper/data"
+)
+
+const nugetSchedule = "18 * * * *"
+const nugetIndexUrl = "https://api.nuget.org/v3/catalog0/index.json"
+
+type nugetIndex struct {
+	IndexId string `json:"@id"`
+	Items   []struct {
+		Url             string `json:"@id"`
+		Type            string `json:"@type"`
+		CommitId        string `json:"commitId"`
+		CommitTimeStamp string `json:"commitTimeStamp"`
+		CommitTime      time.Time
+	}
+}
+
+type nugetPage struct {
+	PageId string `json:"@id"`
+	Items  []struct {
+		Url             string `json:"@id"`
+		Type            string `json:"@type"`
+		CommitTimeStamp string `json:"commitTimeStamp"`
+		CommitTime      time.Time
+		NugetId         string `json:"nuget:id"`
+		NugetVersion    string `json:"nuget:version"`
+	}
+}
+
+type Nuget struct {
+	LatestRun time.Time
+}
+
+func NewNuget() *Nuget {
+	return &Nuget{}
+}
+
+func (ingestor *Nuget) Schedule() string {
+	return nugetSchedule
+}
+
+func (ingestor *Nuget) Ingest() []data.PackageVersion {
+	ingestor.LatestRun = time.Now().Add(-48 * time.Hour)
+	packages := ingestor.ingestURL(nugetIndexUrl)
+	ingestor.LatestRun = time.Now()
+	return packages
+}
+
+func (ingestor *Nuget) ingestURL(url string) []data.PackageVersion {
+	var results []data.PackageVersion
+
+	results, err := ingestor.getIndex(url)
+	if err != nil {
+		log.WithFields(log.Fields{"ingestor": "nuget", "error": err}).Error()
+	}
+
+	return results
+}
+
+func (ingestor *Nuget) getIndex(url string) ([]data.PackageVersion, error) {
+	var results []data.PackageVersion
+
+	response, err := http.Get(url)
+	if err != nil {
+		return results, err
+	}
+	defer response.Body.Close()
+
+	body, _ := ioutil.ReadAll(response.Body)
+	var index nugetIndex
+	json.Unmarshal(body, &index)
+
+	for i, item := range index.Items {
+		item.CommitTime, _ = time.Parse(time.RFC3339, item.CommitTimeStamp)
+		if item.CommitTime.After(ingestor.LatestRun) {
+			fmt.Printf("Page %d - %s - %s\n", i, item.Url, item.Type)
+			pageResults, err := ingestor.getPage(item.Url)
+			if err != nil {
+				return results, nil
+			}
+			results = append(results, pageResults...)
+		}
+	}
+
+	return results, nil
+}
+
+func (ingestor *Nuget) getPage(url string) ([]data.PackageVersion, error) {
+	fmt.Printf("Getting page %s\n", url)
+	var results []data.PackageVersion
+
+	response, err := http.Get(url)
+	if err != nil {
+		return []data.PackageVersion{}, err
+	}
+	defer response.Body.Close()
+
+	body, _ := ioutil.ReadAll(response.Body)
+	var page nugetPage
+	json.Unmarshal(body, &page)
+	fmt.Printf("Page %s %d\n", page.PageId, len(page.Items))
+
+	for _, item := range page.Items {
+		item.CommitTime, _ = time.Parse(time.RFC3339, item.CommitTimeStamp)
+		if item.CommitTime.After(ingestor.LatestRun) {
+			results = append(results,
+				data.PackageVersion{
+					Platform:  "nuget",
+					Name:      item.NugetId,
+					Version:   item.NugetVersion,
+					CreatedAt: item.CommitTime,
+				})
+		} else {
+			fmt.Printf("Skipping %s\n", item)
+		}
+	}
+
+	return results, nil
+}

--- a/ingestors/nuget.go
+++ b/ingestors/nuget.go
@@ -77,9 +77,12 @@ func (ingestor *Nuget) getIndex(url string) ([]data.PackageVersion, error) {
 	}
 	defer response.Body.Close()
 
-	body, _ := ioutil.ReadAll(response.Body)
 	var index nugetIndex
-	json.Unmarshal(body, &index)
+	body, _ := ioutil.ReadAll(response.Body)
+	err = json.Unmarshal(body, &index)
+	if err != nil {
+		return results, err
+	}
 
 	for _, page := range index.Pages {
 		page.CommitTime, _ = time.Parse(time.RFC3339, page.CommitTimeStamp)
@@ -106,7 +109,10 @@ func (ingestor *Nuget) getPage(url string) ([]data.PackageVersion, error) {
 
 	body, _ := ioutil.ReadAll(response.Body)
 	var page nugetPage
-	json.Unmarshal(body, &page)
+	err = json.Unmarshal(body, &page)
+	if err != nil {
+		return results, err
+	}
 
 	for _, pkg := range page.Packages {
 		pkg.CommitTime, _ = time.Parse(time.RFC3339, pkg.CommitTimeStamp)

--- a/ingestors/nuget.go
+++ b/ingestors/nuget.go
@@ -47,9 +47,9 @@ func (ingestor *Nuget) Schedule() string {
 }
 
 func (ingestor *Nuget) Ingest() []data.PackageVersion {
-	// Until we save LatestRun state, begin with the last 24 hours.
+	// Until we save LatestRun state, go back to a 4x multiple of the frequency: 20 min.
 	if ingestor.LatestRun.IsZero() {
-		ingestor.LatestRun = time.Now().Add(-24 * time.Hour)
+		ingestor.LatestRun = time.Now().Add(-20 * time.Minute)
 	}
 	packages := ingestor.ingestURL(nugetIndexUrl)
 	ingestor.LatestRun = time.Now()

--- a/ingestors/nuget.go
+++ b/ingestors/nuget.go
@@ -13,6 +13,7 @@ import (
 
 const nugetSchedule = "*/5 * * * *"
 const nugetIndexUrl = "https://api.nuget.org/v3/catalog0/index.json"
+const defaultLatestRun = -120 * time.Minute
 
 type nugetIndex struct {
 	IndexId string `json:"@id"`
@@ -47,9 +48,9 @@ func (ingestor *Nuget) Schedule() string {
 }
 
 func (ingestor *Nuget) Ingest() []data.PackageVersion {
-	// Until we save LatestRun state, go back two hours by default.
+	// Until we save LatestRun state, we need to set a LatestRun to avoid scanning every single release in the index.
 	if ingestor.LatestRun.IsZero() {
-		ingestor.LatestRun = time.Now().Add(-120 * time.Minute)
+		ingestor.LatestRun = time.Now().Add(defaultLatestRun)
 	}
 	packages := ingestor.ingestURL(nugetIndexUrl)
 	ingestor.LatestRun = time.Now()

--- a/ingestors/nuget.go
+++ b/ingestors/nuget.go
@@ -47,9 +47,9 @@ func (ingestor *Nuget) Schedule() string {
 }
 
 func (ingestor *Nuget) Ingest() []data.PackageVersion {
-	// Until we save LatestRun state, go back to a 4x multiple of the frequency: 20 min.
+	// Until we save LatestRun state, go back two hours by default.
 	if ingestor.LatestRun.IsZero() {
-		ingestor.LatestRun = time.Now().Add(-20 * time.Minute)
+		ingestor.LatestRun = time.Now().Add(-120 * time.Minute)
 	}
 	packages := ingestor.ingestURL(nugetIndexUrl)
 	ingestor.LatestRun = time.Now()

--- a/ingestors/nuget.go
+++ b/ingestors/nuget.go
@@ -11,7 +11,7 @@ import (
 	"github.com/librariesio/depper/data"
 )
 
-const nugetSchedule = "18 * * * *"
+const nugetSchedule = "*/5 * * * *"
 const nugetIndexUrl = "https://api.nuget.org/v3/catalog0/index.json"
 
 type nugetIndex struct {

--- a/ingestors/nuget.go
+++ b/ingestors/nuget.go
@@ -27,7 +27,6 @@ type nugetPage struct {
 	PageId   string `json:"@id"`
 	Packages []struct {
 		Url             string `json:"@id"`
-		Type            string `json:"@type"`
 		CommitTimeStamp string `json:"commitTimeStamp"`
 		CommitTime      time.Time
 		Name            string `json:"nuget:id"`

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func (depper *Depper) registerIngestors() {
 	depper.registerIngestor(ingestors.NewGo())
 	depper.registerIngestor(ingestors.NewMavenCentral())
 	depper.registerIngestor(ingestors.NewCargo())
+	depper.registerIngestor(ingestors.NewNuget())
 }
 
 func (depper *Depper) registerIngestor(ingestor ingestors.Ingestor) {


### PR DESCRIPTION
### Existing sync strategy (rake downloads:nuget)

* save the last most-recently-updated 4 pages of package names to redis
* sync the last most-recently-updated 3 pages of packages

### New sync strategy (depper)

* sync all package versions updated >= LatestRun (defaults to 1.day.ago)


```
...
time="2021-01-28T11:29:54-05:00" level=info msg="Depper publish" name=LykkeBiz.OpenVASP.Transactions.Client platform=nuget version=9.1.0
time="2021-01-28T11:29:54-05:00" level=info msg="Depper publish" name=RealoAPI platform=nuget version=1.0.2
time="2021-01-28T11:29:54-05:00" level=info msg="Depper publish" name=Mosaik.FrontEnd.Topics platform=nuget version=0.0.15494
time="2021-01-28T11:29:54-05:00" level=info msg="Depper publish" name=Slack.Webhooks.Integration platform=nuget version=1.0.0
...
```

### Cross-checking results

We can view [this website search](https://www.nuget.org/packages?packagetype=&sortby=created-desc&q=&prerel=True) to match the most recent against Depper's list