### PR TITLE
Allow ingestors to define their own TTL

### DIFF
--- a/ingestors/maven_central.go
+++ b/ingestors/maven_central.go
@@ -1,12 +1,14 @@
 package ingestors
 
 import (
+	"time"
+
 	"github.com/librariesio/depper/data"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 const mavenCentralSchedule = "@every 12h"
+const ttlHours = 168 * time.Hour // 1 Week
 
 const mavenCentralUrl = "https://maven.libraries.io/mavenCentral/recent"
 
@@ -20,6 +22,10 @@ func NewMavenCentral() *MavenCentral {
 
 func (ingestor *MavenCentral) Schedule() string {
 	return mavenCentralSchedule
+}
+
+func (ingestor *MavenCentral) TTLHours() time.Duration {
+	return ttlHours
 }
 
 func (ingestor *MavenCentral) Ingest() []data.PackageVersion {

--- a/ingestors/maven_central.go
+++ b/ingestors/maven_central.go
@@ -8,7 +8,7 @@ import (
 )
 
 const mavenCentralSchedule = "@every 12h"
-const ttlHours = 168 * time.Hour // 1 Week
+const ttl = 168 * time.Hour // 1 Week
 
 const mavenCentralUrl = "https://maven.libraries.io/mavenCentral/recent"
 
@@ -24,8 +24,8 @@ func (ingestor *MavenCentral) Schedule() string {
 	return mavenCentralSchedule
 }
 
-func (ingestor *MavenCentral) TTLHours() time.Duration {
-	return ttlHours
+func (ingestor *MavenCentral) TTL() time.Duration {
+	return ttl
 }
 
 func (ingestor *MavenCentral) Ingest() []data.PackageVersion {

--- a/ingestors/ttler.go
+++ b/ingestors/ttler.go
@@ -1,0 +1,7 @@
+package ingestors
+
+import "time"
+
+type TTLer interface {
+	TTLHours() time.Duration
+}

--- a/ingestors/ttler.go
+++ b/ingestors/ttler.go
@@ -3,5 +3,5 @@ package ingestors
 import "time"
 
 type TTLer interface {
-	TTLHours() time.Duration
+	TTL() time.Duration
 }

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/librariesio/depper/data"
 	"github.com/librariesio/depper/ingestors"
@@ -13,6 +14,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/writer"
 )
+
+const defaultTTL = 24 * time.Hour
 
 type Depper struct {
 	pipeline           *publishers.Pipeline
@@ -47,15 +50,21 @@ func (depper *Depper) registerIngestors() {
 	depper.registerIngestorStream(ingestors.NewNPM())
 	depper.registerIngestor(ingestors.NewElm())
 	depper.registerIngestor(ingestors.NewGo())
-	// depper.registerIngestor(ingestors.NewMavenCentral())
+	depper.registerIngestor(ingestors.NewMavenCentral())
 	depper.registerIngestor(ingestors.NewCargo())
 }
 
 func (depper *Depper) registerIngestor(ingestor ingestors.Ingestor) {
 	c := cron.New()
 	ingestAndPublish := func() {
+		ttl := defaultTTL
+
+		if ttler, ok := ingestor.(ingestors.TTLer); ok {
+			ttl = ttler.TTLHours()
+		}
+
 		for _, packageVersion := range ingestor.Ingest() {
-			depper.pipeline.Publish(packageVersion)
+			depper.pipeline.Publish(ttl, packageVersion)
 		}
 	}
 
@@ -80,7 +89,7 @@ func (depper *Depper) registerIngestorStream(ingestor ingestors.StreamingIngesto
 	go ingestor.Ingest(packageVersions)
 	go func() {
 		for packageVersion := range packageVersions {
-			depper.pipeline.Publish(packageVersion)
+			depper.pipeline.Publish(defaultTTL, packageVersion)
 		}
 	}()
 }

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func (depper *Depper) registerIngestor(ingestor ingestors.Ingestor) {
 		ttl := defaultTTL
 
 		if ttler, ok := ingestor.(ingestors.TTLer); ok {
-			ttl = ttler.TTLHours()
+			ttl = ttler.TTL()
 		}
 
 		for _, packageVersion := range ingestor.Ingest() {

--- a/publishers/pipeline.go
+++ b/publishers/pipeline.go
@@ -37,11 +37,13 @@ func (pipeline *Pipeline) run() {
 }
 
 func (pipeline *Pipeline) process(publishing publishing) {
-	if pipeline.shouldPublish(publishing) {
-		for _, publisher := range pipeline.publishers {
-			// Publish each packageversion to all publishers
-			publisher.Publish(publishing.PackageVersion)
-		}
+	if !pipeline.shouldPublish(publishing) {
+		return
+	}
+
+	for _, publisher := range pipeline.publishers {
+		// Publish each packageversion to all publishers
+		publisher.Publish(publishing.PackageVersion)
 	}
 }
 

--- a/publishers/pipeline.go
+++ b/publishers/pipeline.go
@@ -1,21 +1,20 @@
 package publishers
 
 import (
+	"context"
 	"time"
 
 	"github.com/librariesio/depper/data"
+	"github.com/librariesio/depper/redis"
+	log "github.com/sirupsen/logrus"
 )
 
 const maxQueueSize = 1000
 
-type Publisher interface {
-	Publish(data.PackageVersion)
-}
-
 type Pipeline struct {
 	publishers      []Publisher
 	LastPublishedAt time.Time
-	queue           chan data.PackageVersion
+	queue           chan publishing
 }
 
 func NewPipeline() *Pipeline {
@@ -25,24 +24,36 @@ func NewPipeline() *Pipeline {
 	return pipeline
 }
 
-func (pipeline *Pipeline) Publish(packageVersion data.PackageVersion) {
-	pipeline.queue <- packageVersion
+func (pipeline *Pipeline) Publish(ttl time.Duration, packageVersion data.PackageVersion) {
+	pipeline.queue <- publishing{PackageVersion: packageVersion, ttl: ttl}
 }
 
 func (pipeline *Pipeline) run() {
-	pipeline.queue = make(chan data.PackageVersion, maxQueueSize)
+	pipeline.queue = make(chan publishing, maxQueueSize)
 
-	for packageVersion := range pipeline.queue {
-		pipeline.process(packageVersion)
+	for publishing := range pipeline.queue {
+		pipeline.process(publishing)
 	}
 }
 
-func (pipeline *Pipeline) process(packageVersion data.PackageVersion) {
-	// TODO move deduping code here
-	for _, publisher := range pipeline.publishers {
-		// Publish each packageversion to all publishers
-		publisher.Publish(packageVersion)
+func (pipeline *Pipeline) process(publishing publishing) {
+	if pipeline.shouldPublish(publishing) {
+		for _, publisher := range pipeline.publishers {
+			// Publish each packageversion to all publishers
+			publisher.Publish(publishing.PackageVersion)
+		}
 	}
+}
+
+func (pipeline *Pipeline) shouldPublish(publishing publishing) bool {
+	wasSet, err := redis.Client.SetNX(context.Background(), publishing.Key(), true, publishing.ttl).Result()
+
+	if err != nil {
+		log.WithFields(log.Fields{"publisher": "pipeline"}).Error(err)
+		return false
+	}
+
+	return wasSet
 }
 
 // Registers a publisher on the pipeline

--- a/publishers/publisher.go
+++ b/publishers/publisher.go
@@ -1,0 +1,7 @@
+package publishers
+
+import "github.com/librariesio/depper/data"
+
+type Publisher interface {
+	Publish(data.PackageVersion)
+}

--- a/publishers/publishing.go
+++ b/publishers/publishing.go
@@ -1,0 +1,17 @@
+package publishers
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/librariesio/depper/data"
+)
+
+type publishing struct {
+	data.PackageVersion
+	ttl time.Duration
+}
+
+func (p *publishing) Key() string {
+	return fmt.Sprintf("depper:ingest:%s:%s:%s", p.Platform, p.Name, p.Version)
+}


### PR DESCRIPTION
Also moves the deduping logic to the publishing pipeline.