### PR TITLE
Adds Packagist ingestor.

### DIFF
--- a/ingestors/packagist.go
+++ b/ingestors/packagist.go
@@ -43,16 +43,14 @@ func (ingestor *Packagist) ingestURL(feedUrl string) []data.PackageVersion {
 	}
 
 	for _, item := range feed.Items {
-		if item.PublishedParsed.After(ingestor.LatestRun) {
-			nameAndVersion := strings.SplitN(item.GUID, " ", 2)
-			results = append(results,
-				data.PackageVersion{
-					Platform:  "packagist",
-					Name:      nameAndVersion[0],
-					Version:   nameAndVersion[1],
-					CreatedAt: *item.PublishedParsed,
-				})
-		}
+		nameAndVersion := strings.SplitN(item.GUID, " ", 2)
+		results = append(results,
+			data.PackageVersion{
+				Platform:  "packagist",
+				Name:      nameAndVersion[0],
+				Version:   nameAndVersion[1],
+				CreatedAt: *item.PublishedParsed,
+			})
 	}
 
 	return results

--- a/ingestors/packagist.go
+++ b/ingestors/packagist.go
@@ -26,10 +26,6 @@ func (ingestor *Packagist) Schedule() string {
 }
 
 func (ingestor *Packagist) Ingest() []data.PackageVersion {
-	// Until we save LatestRun state, go back two hours by default.
-	if ingestor.LatestRun.IsZero() {
-		ingestor.LatestRun = time.Now().Add(-120 * time.Minute)
-	}
 	packages := ingestor.ingestURL(packagistReleasesUrl)
 	ingestor.LatestRun = time.Now()
 	return packages

--- a/ingestors/packagist.go
+++ b/ingestors/packagist.go
@@ -1,0 +1,63 @@
+package ingestors
+
+import (
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/librariesio/depper/data"
+	"github.com/mmcdole/gofeed"
+)
+
+const packagistSchedule = "*/15 * * * *"
+const packagistReleasesUrl = "https://packagist.org/feeds/releases.rss"
+
+type Packagist struct {
+	LatestRun time.Time
+}
+
+func NewPackagist() *Packagist {
+	return &Packagist{}
+}
+
+func (ingestor *Packagist) Schedule() string {
+	return packagistSchedule
+}
+
+func (ingestor *Packagist) Ingest() []data.PackageVersion {
+	// Until we save LatestRun state, go back two hours by default.
+	if ingestor.LatestRun.IsZero() {
+		ingestor.LatestRun = time.Now().Add(-120 * time.Minute)
+	}
+	packages := ingestor.ingestURL(packagistReleasesUrl)
+	ingestor.LatestRun = time.Now()
+	return packages
+}
+
+func (ingestor *Packagist) ingestURL(feedUrl string) []data.PackageVersion {
+	var results []data.PackageVersion
+
+	fp := gofeed.NewParser()
+
+	feed, err := fp.ParseURL(packagistReleasesUrl)
+	if err != nil {
+		log.WithFields(log.Fields{"ingestor": "packagist"}).Error(err)
+		return results
+	}
+
+	for _, item := range feed.Items {
+		if item.PublishedParsed.After(ingestor.LatestRun) {
+			nameAndVersion := strings.SplitN(item.GUID, " ", 2)
+			results = append(results,
+				data.PackageVersion{
+					Platform:  "packagist",
+					Name:      nameAndVersion[0],
+					Version:   nameAndVersion[1],
+					CreatedAt: *item.PublishedParsed,
+				})
+		}
+	}
+
+	return results
+}

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func (depper *Depper) registerIngestors() {
 	depper.registerIngestor(ingestors.NewGo())
 	// depper.registerIngestor(ingestors.NewMavenCentral())
 	depper.registerIngestor(ingestors.NewCargo())
+	depper.registerIngestor(ingestors.NewPackagist())
 }
 
 func (depper *Depper) registerIngestor(ingestor ingestors.Ingestor) {


### PR DESCRIPTION
### Existing sync strategy (rake downloads:packagist)

* sync the latest 40 recently-released releases' packages
* sync the latest 40 recently-released packages

### New sync strategy (depper)

* sync the latest 40 recently-released releases 

Explanation: I don't think we need to ingest recently-releases packages too -- we'll get those when their first versions are published?

e.g.

```
...
time="2021-01-29T12:30:00-05:00" level=info msg="Depper publish" name=baraja-core/doctrine-mail-message platform=packagist version=v1.1.1
time="2021-01-29T12:30:00-05:00" level=info msg="Depper publish" name=dizatech/pacman platform=packagist version=v1.0.6
time="2021-01-29T12:30:00-05:00" level=info msg="Depper publish" name=uspdev/replicado platform=packagist version=1.6.3
...
```

NB the Packagist feed does *not* include development releases.