### PR TITLE
Disable Maven again temporarily

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func (depper *Depper) registerIngestors() {
 	depper.registerIngestorStream(ingestors.NewNPM())
 	depper.registerIngestor(ingestors.NewElm())
 	depper.registerIngestor(ingestors.NewGo())
-	depper.registerIngestor(ingestors.NewMavenCentral())
+	// depper.registerIngestor(ingestors.NewMavenCentral())
 	depper.registerIngestor(ingestors.NewCargo())
 	depper.registerIngestor(ingestors.NewNuget())
 	depper.registerIngestor(ingestors.NewPackagist())


### PR DESCRIPTION
We're getting alerts that Maven is clogging up the queue again:

![Screen Shot 2021-02-02 at 10 39 54 PM](https://user-images.githubusercontent.com/5054/106695101-eb815e80-65a7-11eb-9c07-da25a2e88042.png)

My brain is not functioning ATTM so my only idea is to disable it until tmw.