### PR TITLE
Bump maven ttl to 10 days

### DIFF
--- a/ingestors/maven.go
+++ b/ingestors/maven.go
@@ -8,7 +8,7 @@ import (
 )
 
 const mavenSchedule = "@every 1h"
-const mavenTTL = 168 * time.Hour // 1 Week
+const mavenTTL = 240 * time.Hour // 10 days
 const (
 	MavenAtlassian   MavenRepository = "maven_atlassian"
 	MavenHortonworks MavenRepository = "maven_hortonworks"


### PR DESCRIPTION
I wanted to use a bookmark but we thought of some edge cases where updated_at could be slightly off if a package release slipped in while an index was being created. This achieves the same basic goal of not redoing work since we will replace all package versions in our maven services approx every 7 days. This gives us a bit of a buffer.