### PR TITLE
Add Drupal ingestor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/librariesio/depper
 go 1.16
 
 require (
+	github.com/PuerkitoBio/goquery v1.5.1 // indirect
 	github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d
 	github.com/bitly/go-simplejson v0.5.0 // indirect
 	github.com/buger/jsonparser v1.1.0

--- a/ingestors/bookmarks.go
+++ b/ingestors/bookmarks.go
@@ -20,7 +20,7 @@ func setBookmark(namer Namer, bookmark string) (string, error) {
 	return bookmark, nil
 }
 
-// Use to set a string bookmark time for an ingestor
+// Use to set a datetime bookmark time for an ingestor
 func setBookmarkTime(namer Namer, bookmarkTime time.Time) (time.Time, error) {
 	if _, err := setBookmark(namer, bookmarkTime.Format(time.RFC3339)); err != nil {
 		return bookmarkTime, err

--- a/ingestors/drupal.go
+++ b/ingestors/drupal.go
@@ -70,7 +70,6 @@ func (ingestor *Drupal) Ingest() []data.PackageVersion {
 	}
 
 	if len(results) > 0 {
-		log.Printf("Setting bookmark to %s\n", data.MaxCreatedAt(results))
 		if _, err := setBookmarkTime(ingestor, data.MaxCreatedAt(results)); err != nil {
 			log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Fatal(err)
 		}

--- a/ingestors/drupal.go
+++ b/ingestors/drupal.go
@@ -1,0 +1,124 @@
+package ingestors
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/librariesio/depper/data"
+	"github.com/mmcdole/gofeed"
+)
+
+const drupalSchedule = "*/5 * * * *"
+const drupalModulesUrl = "https://www.drupal.org/project/project_module?page=%d&solrsort=ds_project_latest_release%20desc"
+const drupalReleasesUrl = "https://www.drupal.org/node/%s/release/feed"
+
+type Drupal struct {
+	LatestRun time.Time
+}
+
+func NewDrupal() *Drupal {
+	return &Drupal{}
+}
+
+func (ingestor *Drupal) Schedule() string {
+	return drupalSchedule
+}
+
+func (ingestor *Drupal) Name() string {
+	return "drupal"
+}
+
+func (ingestor *Drupal) Ingest() []data.PackageVersion {
+	var results []data.PackageVersion
+
+	// Until we save LatestRun state, we need to set a LatestRun to avoid scanning every single release in the index.
+	if ingestor.LatestRun.IsZero() {
+		ingestor.LatestRun = time.Now().Add(-5 * 1 * 24 * time.Hour)
+	}
+
+	page := 0
+	done := false
+	for page < 1000 && !done {
+		doc, err := getHtmlDocument(fmt.Sprintf(drupalModulesUrl, page))
+		if err != nil {
+			log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Fatal()
+		}
+
+		doc.Find(".node-project-module").Each(func(i int, s *goquery.Selection) {
+			if !done {
+				var id string
+				if idAttr, exists := s.Attr("id"); exists {
+					parts := strings.SplitN(idAttr, "-", 2) // e.g. "node-1234"
+					id = parts[1]
+				}
+				packageResults := ingestor.getVersions(id)
+				if len(packageResults) == 0 { // last page didnt' have any new versions, so break and return all collected versions
+					done = true
+				} else {
+					results = append(results, packageResults...)
+				}
+			}
+		})
+		page++
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	ingestor.LatestRun = time.Now()
+
+	return results
+}
+
+func (ingestor *Drupal) getVersions(id string) []data.PackageVersion {
+	var results []data.PackageVersion
+	fp := gofeed.NewParser()
+
+	feed, err := fp.ParseURL(fmt.Sprintf(drupalReleasesUrl, id))
+	if err != nil {
+		log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Error(err)
+		return results
+	}
+
+	for _, item := range feed.Items { // Mon Jan 2 15:04:05 -0700 MST 2006
+		createdAtTime, _ := time.Parse(time.RFC1123, item.Published)
+		nameAndVersion := strings.SplitN(item.Title, " ", 2) // e.g. ctools 7.x-1.19
+		if createdAtTime.After(ingestor.LatestRun) {
+			results = append(results,
+				data.PackageVersion{
+					Platform:  "drupal",
+					Name:      nameAndVersion[0],
+					Version:   nameAndVersion[1],
+					CreatedAt: createdAtTime,
+				})
+		}
+	}
+
+	return results
+}
+
+func getHtmlDocument(url string) (*goquery.Document, error) {
+	res, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("Status code error for %s: %d %s", url, res.StatusCode, res.Status)
+	}
+
+	doc, err := goquery.NewDocumentFromReader(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return doc, nil
+}
+
+// func (ingestor *Drupal) ingestURL(feedUrl string) []data.PackageVersion {
+
+// 	return results
+// }

--- a/ingestors/drupal.go
+++ b/ingestors/drupal.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mmcdole/gofeed"
 )
 
-const drupalSchedule = "*/5 * * * *"
+const drupalSchedule = "0 */4 * * *"
 const drupalModulesUrl = "https://www.drupal.org/project/project_module?page=%d&solrsort=ds_project_latest_release+desc"
 const drupalReleasesUrl = "https://www.drupal.org/node/%s/release/feed"
 

--- a/ingestors/drupal.go
+++ b/ingestors/drupal.go
@@ -88,7 +88,7 @@ func (ingestor *Drupal) getVersions(id string, bookmark time.Time) []data.Packag
 		return results
 	}
 
-	for _, item := range feed.Items { // Mon Jan 2 15:04:05 -0700 MST 2006
+	for _, item := range feed.Items {
 		createdAtTime, _ := time.Parse(time.RFC1123, item.Published)
 		nameAndVersion := strings.SplitN(item.Title, " ", 2) // e.g. ctools 7.x-1.19
 		if createdAtTime.After(bookmark) {

--- a/ingestors/drupal.go
+++ b/ingestors/drupal.go
@@ -58,7 +58,7 @@ func (ingestor *Drupal) Ingest() []data.PackageVersion {
 					id = parts[1]
 				}
 				packageResults := ingestor.getVersions(id)
-				if len(packageResults) == 0 { // last page didnt' have any new versions, so break and return all collected versions
+				if len(packageResults) == 0 { // last page didn't have any new versions, which means we don't have to keep looking at older packages
 					done = true
 				} else {
 					results = append(results, packageResults...)
@@ -118,8 +118,3 @@ func getHtmlDocument(url string) (*goquery.Document, error) {
 
 	return doc, nil
 }
-
-// func (ingestor *Drupal) ingestURL(feedUrl string) []data.PackageVersion {
-
-// 	return results
-// }

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func (depper *Depper) registerIngestors() {
 	depper.registerIngestor(ingestors.NewCargo())
 	depper.registerIngestor(ingestors.NewNuget())
 	depper.registerIngestor(ingestors.NewPackagist())
+	depper.registerIngestor(ingestors.NewDrupal())
 	depper.registerIngestor(ingestors.NewPyPiRss())
 	depper.registerIngestor(ingestors.NewPyPiXmlRpc())
 	depper.registerIngestor(ingestors.NewConda(ingestors.CondaForge))


### PR DESCRIPTION
Adds ingestor for Drupal repo, which is a repository of Composer packages:

```
...
time="2021-08-28T00:51:24-04:00" level=info msg="Depper publish" created="2021-08-23 10:03:01 +0000 +0000" name=date_augmenter platform=drupal version=1.0.0-rc1
time="2021-08-28T00:51:24-04:00" level=info msg="Depper publish" created="2021-08-23 07:06:12 +0000 +0000" name=cypress platform=drupal version=2.3.18
time="2021-08-28T00:51:24-04:00" level=info msg="Depper publish" created="2021-08-23 06:53:52 +0000 +0000" name=phoney platform=drupal version=1.0.0
time="2021-08-28T00:51:24-04:00" level=info msg="Depper publish" created="2021-08-23 06:50:26 +0000 +0000" name=phoney platform=drupal version=1.0.x-dev
time="2021-08-28T00:51:24-04:00" level=info msg="Depper publish" created="2021-08-23 05:35:58 +0000 +0000" name=ri platform=drupal version=8.x-1.x-dev
...
```
