### PR TITLE
Re-enable pypi xmlrpc ingestor and skip bad bytes in XML.

### DIFF
--- a/ingestors/pypi_xml_rpc.go
+++ b/ingestors/pypi_xml_rpc.go
@@ -53,6 +53,7 @@ func (ingestor *PyPiXmlRpc) Ingest() []data.PackageVersion {
 		if strings.Contains(fmt.Sprint(err), "illegal character code") {
 			// If we encounter illegal characters in the XML, ignore this page and treat it like an empty response.
 			log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Error(err)
+			log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Info(fmt.Sprintf("Skipping page from timestamp %d", since.Unix()))
 			response = [][]interface{}{}
 		} else {
 			log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Fatal(err)

--- a/ingestors/pypi_xml_rpc.go
+++ b/ingestors/pypi_xml_rpc.go
@@ -1,6 +1,8 @@
 package ingestors
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/librariesio/depper/data"
@@ -48,7 +50,13 @@ func (ingestor *PyPiXmlRpc) Ingest() []data.PackageVersion {
 
 	err = client.Call("changelog", int(since.Unix()), &response)
 	if err != nil {
-		log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Fatal(err)
+		if strings.Contains(fmt.Sprint(err), "illegal character code") {
+			// If we encounter illegal characters in the XML, ignore this page and treat it like an empty response.
+			log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Error(err)
+			response = [][]interface{}{}
+		} else {
+			log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Fatal(err)
+		}
 	}
 
 	for _, log := range response {
@@ -65,10 +73,8 @@ func (ingestor *PyPiXmlRpc) Ingest() []data.PackageVersion {
 		}
 	}
 
-	if len(results) > 0 {
-		if _, err := setBookmarkTime(ingestor, data.MaxCreatedAt(results)); err != nil {
-			log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Fatal(err)
-		}
+	if _, err := setBookmarkTime(ingestor, data.MaxCreatedAt(results)); err != nil {
+		log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Fatal(err)
 	}
 
 	return results

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func (depper *Depper) registerIngestors() {
 	depper.registerIngestor(ingestors.NewPackagist())
 	depper.registerIngestor(ingestors.NewDrupal())
 	depper.registerIngestor(ingestors.NewPyPiRss())
-	// depper.registerIngestor(ingestors.NewPyPiXmlRpc())
+	depper.registerIngestor(ingestors.NewPyPiXmlRpc())
 	depper.registerIngestor(ingestors.NewConda(ingestors.CondaForge))
 	depper.registerIngestor(ingestors.NewConda(ingestors.CondaMain))
 }


### PR DESCRIPTION
The Pypi XML RPC ingestor picked up some bad data in the "changelog" method at this timestamp: `"2021-12-11T00:05:11Z"`:

`<value><string>add source file azure-agrifood-farming-100.10.7.tar.gz</string></value>`

If you inspect the original fragment, there are some bytes that are probably ANSI deletion codes: `ESC [ m ESC K`. 

Since these aren't valid XML bytes, [go rejects them and raises an error](https://github.com/golang/go/blob/1540239f48f6beaa1cae6b34d00d74860366da7d/src/encoding/xml/xml.go#L1138).

This change just ignores the whole page if we run into this, since grabbing the page *except* the invalid part seems like a can of worms.



