### PR TITLE
Log packages that we skip bc they're stored already with a TTL

### DIFF
--- a/publishers/pipeline.go
+++ b/publishers/pipeline.go
@@ -38,6 +38,13 @@ func (pipeline *Pipeline) run() {
 
 func (pipeline *Pipeline) process(publishing publishing) {
 	if !pipeline.shouldPublish(publishing) {
+		log.WithFields(log.Fields{
+			"platform": publishing.PackageVersion.Platform,
+			"name":     publishing.PackageVersion.Name,
+			"version":  publishing.PackageVersion.Version,
+			"created":  publishing.PackageVersion.CreatedAt,
+		}).
+			Info("Depper skip")
 		return
 	}
 


### PR DESCRIPTION
We have a short-circuit on publishing packages that we see by storing them in Redis with a TTL (e.g. 10 days for maven).

This would log any packages that we *don't* publish, because we've seen some missing versions from 2 weeks ago that aren't in our depper logs. This would rule out the TTL feature next time this happens.