### PR TITLE
Remove bookmark usage in maven ingestors, in favor of just TTL.

### DIFF
--- a/ingestors/maven.go
+++ b/ingestors/maven.go
@@ -44,12 +44,6 @@ func (ingestor *MavenIngestor) Ingest() []data.PackageVersion {
 		return results
 	}
 
-	if len(results) > 0 {
-		if _, err := setBookmarkTime(ingestor, data.MaxCreatedAt(results)); err != nil {
-			log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Fatal(err)
-		}
-	}
-
 	ingestor.LatestRun = time.Now()
 	return results
 }

--- a/ingestors/maven.go
+++ b/ingestors/maven.go
@@ -8,7 +8,7 @@ import (
 )
 
 const mavenSchedule = "@every 1h"
-const mavenTTL = 240 * time.Hour // 10 days
+const mavenTTL = 720 * time.Hour // 30 days
 const (
 	MavenAtlassian   MavenRepository = "maven_atlassian"
 	MavenHortonworks MavenRepository = "maven_hortonworks"

--- a/ingestors/maven.go
+++ b/ingestors/maven.go
@@ -36,14 +36,9 @@ func (ingestor *MavenIngestor) Schedule() string {
 }
 
 func (ingestor *MavenIngestor) Ingest() []data.PackageVersion {
-	bookmark, err := getBookmarkTime(ingestor, time.Now().AddDate(-7, 0, 0))
-	if err != nil {
-		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Fatal()
-	}
-
 	parser := ingestor.GetParser()
 
-	results, err := parser.GetPackages(bookmark)
+	results, err := parser.GetPackages()
 	if err != nil {
 		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error()
 		return results

--- a/ingestors/maven_parser.go
+++ b/ingestors/maven_parser.go
@@ -27,7 +27,7 @@ func NewMavenParser(url string, platform string) *MavenParser {
 	}
 }
 
-func (parser *MavenParser) GetPackages(lastRun time.Time) ([]data.PackageVersion, error) {
+func (parser *MavenParser) GetPackages() ([]data.PackageVersion, error) {
 	var results []data.PackageVersion
 
 	response, err := http.Get(parser.URL)
@@ -44,17 +44,13 @@ func (parser *MavenParser) GetPackages(lastRun time.Time) ([]data.PackageVersion
 	}
 
 	for _, maven := range mavens {
-		createdAt := time.Unix(0, maven.LastModified*int64(time.Millisecond))
-
-		if createdAt.After(lastRun) {
-			results = append(results,
-				data.PackageVersion{
-					Platform:  parser.Platform,
-					Name:      maven.Name,
-					Version:   maven.Version,
-					CreatedAt: createdAt,
-				})
-		}
+		results = append(results,
+			data.PackageVersion{
+				Platform:  parser.Platform,
+				Name:      maven.Name,
+				Version:   maven.Version,
+				CreatedAt: time.Unix(0, maven.LastModified*int64(time.Millisecond)),
+			})
 	}
 
 	return results, nil


### PR DESCRIPTION
Currently depper's maven ingestors fetch packages like this:

1) get the bookmark from redis (or default to 7 years ago), e.g. `"depper:bookmark:maven_mavencentral"`
2) fetch the list of recent packages (which is probably just the latest incremental index from the nexus indexers), e.g. `https://maven.libraries.io/mavenCentral/recent`
3) return any releases from that response that have a createdAt *after* the bookmark date
4) set the bookmark in redis to the newest createdAt from those packages
5) pipeline.go: this publishes any releases that don't have a TTL redis key, e.g. `"depper:ingest:maven_mavencentral:org.apache.struts:struts2-core:6.1.1"`

So we basically have two mechanisms of deduping packages depper's published: the bookmark and the TTL.

The bookmark seems to be problematic because these maven incremental indices contain packages that are up to a few weeks old. Here's the current count of 'createdAt' values by day, for the maven central index:

```
 [[Tue, 22 Nov 2022, 8248],
 [Wed, 23 Nov 2022, 7691],
 [Thu, 24 Nov 2022, 7827],
 [Mon, 21 Nov 2022, 4773],
 [Sun, 27 Nov 2022, 3597],
 [Fri, 25 Nov 2022, 6582],
 [Tue, 29 Nov 2022, 1626],
 [Mon, 28 Nov 2022, 3928],
 [Sat, 26 Nov 2022, 3702],
 [Sun, 20 Nov 2022, 2386],
 [Fri, 18 Nov 2022, 167],
 [Thu, 10 Nov 2022, 150],
 [Mon, 14 Nov 2022, 37],
 [Tue, 15 Nov 2022, 38],
 [Mon, 07 Nov 2022, 81],
 [Wed, 16 Nov 2022, 60],
 [Sat, 19 Nov 2022, 10],
 [Tue, 08 Nov 2022, 15],
 [Thu, 17 Nov 2022, 3],
 [Mon, 03 Oct 2022, 5]]
```

Since these could get potentially added to the index *after* depper has run and set a later bookmark, depper will skip those, and Libraries will never know about those releases.

And since we already have the TTL to guard against dupes, I propose removing the bookmarking from the maven ingestor, and extending the TTL keys' redis expiry from 10 days to 30 days. Currently at 10 days, we're only taking up 6MB of redis RAM for *all* maven repo ingestors, so 30 days probably wouldn't be an excessive amount of data either.