### PR TITLE
Adds a "discoveryLag" log field to know explicit lag between creation+discovery

### DIFF
--- a/data/package_version.go
+++ b/data/package_version.go
@@ -3,11 +3,11 @@ package data
 import "time"
 
 type PackageVersion struct {
-	Platform  string
-	Name      string
-	Version   string
-	CreatedAt time.Time
-	Lag       time.Duration
+	Platform     string
+	Name         string
+	Version      string
+	CreatedAt    time.Time
+	DiscoveryLag time.Duration // (time of depper discovery) - (creation time, as reported by repository)
 }
 
 func MaxCreatedAt(packageVersions []PackageVersion) time.Time {

--- a/data/package_version.go
+++ b/data/package_version.go
@@ -7,6 +7,7 @@ type PackageVersion struct {
 	Name      string
 	Version   string
 	CreatedAt time.Time
+	Lag       time.Duration
 }
 
 func MaxCreatedAt(packageVersions []PackageVersion) time.Time {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/librariesio/depper
 
-go 1.18
+go 1.20
 
 require (
 	github.com/PuerkitoBio/goquery v1.5.1

--- a/ingestors/cargo.go
+++ b/ingestors/cargo.go
@@ -1,7 +1,7 @@
 package ingestors
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -43,7 +43,7 @@ func (ingestor *Cargo) ingestURL(url string) []data.PackageVersion {
 
 	defer response.Body.Close()
 
-	body, _ := ioutil.ReadAll(response.Body)
+	body, _ := io.ReadAll(response.Body)
 	err = jsonparser.ObjectEach(body, func(key []byte, value []byte, dataType jsonparser.ValueType, offset int) error {
 		var subErr error
 		if string(key) == "just_updated" || string(key) == "new_crates" {

--- a/ingestors/cargo.go
+++ b/ingestors/cargo.go
@@ -52,6 +52,7 @@ func (ingestor *Cargo) ingestURL(url string) []data.PackageVersion {
 				version, _ := jsonparser.GetString(value, "newest_version")
 				createdAt, _ := jsonparser.GetString(value, "updated_at")
 				createdAtTime, _ := time.Parse(time.RFC3339, createdAt)
+				lag := time.Now().Sub(createdAtTime)
 
 				results = append(
 					results,
@@ -60,6 +61,7 @@ func (ingestor *Cargo) ingestURL(url string) []data.PackageVersion {
 						Name:      name,
 						Version:   version,
 						CreatedAt: createdAtTime,
+						Lag:       lag,
 					},
 				)
 			})

--- a/ingestors/cargo.go
+++ b/ingestors/cargo.go
@@ -52,16 +52,16 @@ func (ingestor *Cargo) ingestURL(url string) []data.PackageVersion {
 				version, _ := jsonparser.GetString(value, "newest_version")
 				createdAt, _ := jsonparser.GetString(value, "updated_at")
 				createdAtTime, _ := time.Parse(time.RFC3339, createdAt)
-				lag := time.Since(createdAtTime)
+				discoveryLag := time.Since(createdAtTime)
 
 				results = append(
 					results,
 					data.PackageVersion{
-						Platform:  "cargo",
-						Name:      name,
-						Version:   version,
-						CreatedAt: createdAtTime,
-						Lag:       lag,
+						Platform:     "cargo",
+						Name:         name,
+						Version:      version,
+						CreatedAt:    createdAtTime,
+						DiscoveryLag: discoveryLag,
 					},
 				)
 			})

--- a/ingestors/cargo.go
+++ b/ingestors/cargo.go
@@ -52,7 +52,7 @@ func (ingestor *Cargo) ingestURL(url string) []data.PackageVersion {
 				version, _ := jsonparser.GetString(value, "newest_version")
 				createdAt, _ := jsonparser.GetString(value, "updated_at")
 				createdAtTime, _ := time.Parse(time.RFC3339, createdAt)
-				lag := time.Now().Sub(createdAtTime)
+				lag := time.Since(createdAtTime)
 
 				results = append(
 					results,

--- a/ingestors/conda_parser.go
+++ b/ingestors/conda_parser.go
@@ -46,7 +46,7 @@ func (parser *CondaParser) GetPackages(lastRun time.Time) ([]data.PackageVersion
 			if timeCode.Before(lastRun) {
 				return nil
 			}
-			lag := time.Now().Sub(timeCode)
+			lag := time.Since(timeCode)
 
 			results = append(results,
 				data.PackageVersion{

--- a/ingestors/conda_parser.go
+++ b/ingestors/conda_parser.go
@@ -46,12 +46,15 @@ func (parser *CondaParser) GetPackages(lastRun time.Time) ([]data.PackageVersion
 			if timeCode.Before(lastRun) {
 				return nil
 			}
+			lag := time.Now().Sub(timeCode)
+
 			results = append(results,
 				data.PackageVersion{
 					Platform:  parser.Platform,
 					Name:      name,
 					Version:   version,
 					CreatedAt: timeCode,
+					Lag:       lag,
 				})
 			return nil
 		})

--- a/ingestors/conda_parser.go
+++ b/ingestors/conda_parser.go
@@ -2,7 +2,7 @@ package ingestors
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -32,7 +32,7 @@ func (parser *CondaParser) GetPackages(lastRun time.Time) ([]data.PackageVersion
 			return results, err
 		}
 		defer response.Body.Close()
-		jsonBody, _ := ioutil.ReadAll(response.Body)
+		jsonBody, _ := io.ReadAll(response.Body)
 		packages, _, _, err := jsonparser.Get(jsonBody, "packages")
 		if err != nil {
 			return results, err

--- a/ingestors/conda_parser.go
+++ b/ingestors/conda_parser.go
@@ -46,15 +46,15 @@ func (parser *CondaParser) GetPackages(lastRun time.Time) ([]data.PackageVersion
 			if timeCode.Before(lastRun) {
 				return nil
 			}
-			lag := time.Since(timeCode)
+			discoveryLag := time.Since(timeCode)
 
 			results = append(results,
 				data.PackageVersion{
-					Platform:  parser.Platform,
-					Name:      name,
-					Version:   version,
-					CreatedAt: timeCode,
-					Lag:       lag,
+					Platform:     parser.Platform,
+					Name:         name,
+					Version:      version,
+					CreatedAt:    timeCode,
+					DiscoveryLag: discoveryLag,
 				})
 			return nil
 		})

--- a/ingestors/drupal.go
+++ b/ingestors/drupal.go
@@ -92,12 +92,14 @@ func (ingestor *Drupal) getVersions(id string, bookmark time.Time) []data.Packag
 		createdAtTime, _ := time.Parse(time.RFC1123, item.Published)
 		nameAndVersion := strings.SplitN(item.Title, " ", 2) // e.g. ctools 7.x-1.19
 		if createdAtTime.After(bookmark) {
+			lag := time.Now().Sub(createdAtTime)
 			results = append(results,
 				data.PackageVersion{
 					Platform:  ingestor.Name(),
 					Name:      nameAndVersion[0],
 					Version:   nameAndVersion[1],
 					CreatedAt: createdAtTime,
+					Lag:       lag,
 				})
 		}
 	}

--- a/ingestors/drupal.go
+++ b/ingestors/drupal.go
@@ -92,7 +92,7 @@ func (ingestor *Drupal) getVersions(id string, bookmark time.Time) []data.Packag
 		createdAtTime, _ := time.Parse(time.RFC1123, item.Published)
 		nameAndVersion := strings.SplitN(item.Title, " ", 2) // e.g. ctools 7.x-1.19
 		if createdAtTime.After(bookmark) {
-			lag := time.Now().Sub(createdAtTime)
+			lag := time.Since(createdAtTime)
 			results = append(results,
 				data.PackageVersion{
 					Platform:  ingestor.Name(),

--- a/ingestors/drupal.go
+++ b/ingestors/drupal.go
@@ -92,14 +92,14 @@ func (ingestor *Drupal) getVersions(id string, bookmark time.Time) []data.Packag
 		createdAtTime, _ := time.Parse(time.RFC1123, item.Published)
 		nameAndVersion := strings.SplitN(item.Title, " ", 2) // e.g. ctools 7.x-1.19
 		if createdAtTime.After(bookmark) {
-			lag := time.Since(createdAtTime)
+			discoveryLag := time.Since(createdAtTime)
 			results = append(results,
 				data.PackageVersion{
-					Platform:  ingestor.Name(),
-					Name:      nameAndVersion[0],
-					Version:   nameAndVersion[1],
-					CreatedAt: createdAtTime,
-					Lag:       lag,
+					Platform:     ingestor.Name(),
+					Name:         nameAndVersion[0],
+					Version:      nameAndVersion[1],
+					CreatedAt:    createdAtTime,
+					DiscoveryLag: discoveryLag,
 				})
 		}
 	}

--- a/ingestors/elm.go
+++ b/ingestors/elm.go
@@ -47,12 +47,14 @@ func (ingestor *Elm) ingestURL(feedUrl string) []data.PackageVersion {
 	for _, item := range feed.Items {
 		parsed, _ := url.Parse(item.Link)
 		parts := strings.Split(parsed.Path, "/")
+		lag := time.Now().Sub(*item.PublishedParsed)
 		results = append(results,
 			data.PackageVersion{
 				Platform:  "elm",
 				Name:      fmt.Sprintf("%s/%s", parts[2], parts[3]),
 				Version:   parts[4],
 				CreatedAt: *item.PublishedParsed,
+				Lag:       lag,
 			})
 	}
 	return results

--- a/ingestors/elm.go
+++ b/ingestors/elm.go
@@ -47,14 +47,14 @@ func (ingestor *Elm) ingestURL(feedUrl string) []data.PackageVersion {
 	for _, item := range feed.Items {
 		parsed, _ := url.Parse(item.Link)
 		parts := strings.Split(parsed.Path, "/")
-		lag := time.Since(*item.PublishedParsed)
+		discoveryLag := time.Since(*item.PublishedParsed)
 		results = append(results,
 			data.PackageVersion{
-				Platform:  "elm",
-				Name:      fmt.Sprintf("%s/%s", parts[2], parts[3]),
-				Version:   parts[4],
-				CreatedAt: *item.PublishedParsed,
-				Lag:       lag,
+				Platform:     "elm",
+				Name:         fmt.Sprintf("%s/%s", parts[2], parts[3]),
+				Version:      parts[4],
+				CreatedAt:    *item.PublishedParsed,
+				DiscoveryLag: discoveryLag,
 			})
 	}
 	return results

--- a/ingestors/elm.go
+++ b/ingestors/elm.go
@@ -47,7 +47,7 @@ func (ingestor *Elm) ingestURL(feedUrl string) []data.PackageVersion {
 	for _, item := range feed.Items {
 		parsed, _ := url.Parse(item.Link)
 		parts := strings.Split(parsed.Path, "/")
-		lag := time.Now().Sub(*item.PublishedParsed)
+		lag := time.Since(*item.PublishedParsed)
 		results = append(results,
 			data.PackageVersion{
 				Platform:  "elm",

--- a/ingestors/go.go
+++ b/ingestors/go.go
@@ -56,7 +56,7 @@ func (ingestor *Go) Ingest() []data.PackageVersion {
 		if module.IsPseudoVersion(version) {
 			continue
 		}
-		lag := time.Now().Sub(createdAtTime)
+		lag := time.Since(createdAtTime)
 
 		results = append(results,
 			data.PackageVersion{

--- a/ingestors/go.go
+++ b/ingestors/go.go
@@ -56,6 +56,7 @@ func (ingestor *Go) Ingest() []data.PackageVersion {
 		if module.IsPseudoVersion(version) {
 			continue
 		}
+		lag := time.Now().Sub(createdAtTime)
 
 		results = append(results,
 			data.PackageVersion{
@@ -63,6 +64,7 @@ func (ingestor *Go) Ingest() []data.PackageVersion {
 				Name:      name,
 				Version:   version,
 				CreatedAt: createdAtTime,
+				Lag:       lag,
 			})
 	}
 	if err := scanner.Err(); err != nil {

--- a/ingestors/go.go
+++ b/ingestors/go.go
@@ -56,15 +56,15 @@ func (ingestor *Go) Ingest() []data.PackageVersion {
 		if module.IsPseudoVersion(version) {
 			continue
 		}
-		lag := time.Since(createdAtTime)
+		discoveryLag := time.Since(createdAtTime)
 
 		results = append(results,
 			data.PackageVersion{
-				Platform:  "go",
-				Name:      name,
-				Version:   version,
-				CreatedAt: createdAtTime,
-				Lag:       lag,
+				Platform:     "go",
+				Name:         name,
+				Version:      version,
+				CreatedAt:    createdAtTime,
+				DiscoveryLag: discoveryLag,
 			})
 	}
 	if err := scanner.Err(); err != nil {

--- a/ingestors/maven_parser.go
+++ b/ingestors/maven_parser.go
@@ -2,7 +2,7 @@ package ingestors
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -36,7 +36,7 @@ func (parser *MavenParser) GetPackages() ([]data.PackageVersion, error) {
 	}
 	defer response.Body.Close()
 
-	body, _ := ioutil.ReadAll(response.Body)
+	body, _ := io.ReadAll(response.Body)
 	var mavens []mavenUpdate
 	err = json.Unmarshal(body, &mavens)
 	if err != nil {

--- a/ingestors/maven_parser.go
+++ b/ingestors/maven_parser.go
@@ -44,12 +44,16 @@ func (parser *MavenParser) GetPackages() ([]data.PackageVersion, error) {
 	}
 
 	for _, maven := range mavens {
+		createdAt := time.Unix(0, maven.LastModified*int64(time.Millisecond))
+		lag := time.Now().Sub(createdAt)
+
 		results = append(results,
 			data.PackageVersion{
 				Platform:  parser.Platform,
 				Name:      maven.Name,
 				Version:   maven.Version,
-				CreatedAt: time.Unix(0, maven.LastModified*int64(time.Millisecond)),
+				CreatedAt: createdAt,
+				Lag:       lag,
 			})
 	}
 

--- a/ingestors/maven_parser.go
+++ b/ingestors/maven_parser.go
@@ -45,7 +45,7 @@ func (parser *MavenParser) GetPackages() ([]data.PackageVersion, error) {
 
 	for _, maven := range mavens {
 		createdAt := time.Unix(0, maven.LastModified*int64(time.Millisecond))
-		lag := time.Now().Sub(createdAt)
+		lag := time.Since(createdAt)
 
 		results = append(results,
 			data.PackageVersion{

--- a/ingestors/maven_parser.go
+++ b/ingestors/maven_parser.go
@@ -45,15 +45,15 @@ func (parser *MavenParser) GetPackages() ([]data.PackageVersion, error) {
 
 	for _, maven := range mavens {
 		createdAt := time.Unix(0, maven.LastModified*int64(time.Millisecond))
-		lag := time.Since(createdAt)
+		discoveryLag := time.Since(createdAt)
 
 		results = append(results,
 			data.PackageVersion{
-				Platform:  parser.Platform,
-				Name:      maven.Name,
-				Version:   maven.Version,
-				CreatedAt: createdAt,
-				Lag:       lag,
+				Platform:     parser.Platform,
+				Name:         maven.Name,
+				Version:      maven.Version,
+				CreatedAt:    createdAt,
+				DiscoveryLag: discoveryLag,
 			})
 	}
 

--- a/ingestors/npm.go
+++ b/ingestors/npm.go
@@ -80,7 +80,7 @@ func (ingestor *NPM) Ingest(results chan data.PackageVersion) {
 				}
 			}
 			if latestVersion != "" {
-				lag := time.Now().Sub(latestTime)
+				lag := time.Since(latestTime)
 				results <- data.PackageVersion{
 					Platform:  "npm",
 					Name:      doc.Name,

--- a/ingestors/npm.go
+++ b/ingestors/npm.go
@@ -80,11 +80,13 @@ func (ingestor *NPM) Ingest(results chan data.PackageVersion) {
 				}
 			}
 			if latestVersion != "" {
+				lag := time.Now().Sub(latestTime)
 				results <- data.PackageVersion{
 					Platform:  "npm",
 					Name:      doc.Name,
 					Version:   latestVersion,
 					CreatedAt: latestTime,
+					Lag:       lag,
 				}
 				if _, err := setBookmark(ingestor, changes.Seq()); err != nil {
 					log.WithFields(log.Fields{"ingestor": "npm"}).Fatal(err)

--- a/ingestors/npm.go
+++ b/ingestors/npm.go
@@ -80,13 +80,13 @@ func (ingestor *NPM) Ingest(results chan data.PackageVersion) {
 				}
 			}
 			if latestVersion != "" {
-				lag := time.Since(latestTime)
+				discoveryLag := time.Since(latestTime)
 				results <- data.PackageVersion{
-					Platform:  "npm",
-					Name:      doc.Name,
-					Version:   latestVersion,
-					CreatedAt: latestTime,
-					Lag:       lag,
+					Platform:     "npm",
+					Name:         doc.Name,
+					Version:      latestVersion,
+					CreatedAt:    latestTime,
+					DiscoveryLag: discoveryLag,
 				}
 				if _, err := setBookmark(ingestor, changes.Seq()); err != nil {
 					log.WithFields(log.Fields{"ingestor": "npm"}).Fatal(err)

--- a/ingestors/nuget.go
+++ b/ingestors/nuget.go
@@ -124,6 +124,7 @@ func (ingestor *Nuget) getPage(url string) ([]data.PackageVersion, error) {
 					Name:      pkg.Name,
 					Version:   pkg.Version,
 					CreatedAt: pkg.CommitTime,
+					Lag:       time.Now().Sub(pkg.CommitTime),
 				},
 			)
 		}

--- a/ingestors/nuget.go
+++ b/ingestors/nuget.go
@@ -2,7 +2,7 @@ package ingestors
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -78,7 +78,7 @@ func (ingestor *Nuget) getIndex(url string) ([]data.PackageVersion, error) {
 	defer response.Body.Close()
 
 	var index nugetIndex
-	body, _ := ioutil.ReadAll(response.Body)
+	body, _ := io.ReadAll(response.Body)
 	err = json.Unmarshal(body, &index)
 	if err != nil {
 		return results, err
@@ -107,7 +107,7 @@ func (ingestor *Nuget) getPage(url string) ([]data.PackageVersion, error) {
 	}
 	defer response.Body.Close()
 
-	body, _ := ioutil.ReadAll(response.Body)
+	body, _ := io.ReadAll(response.Body)
 	var page nugetPage
 	err = json.Unmarshal(body, &page)
 	if err != nil {

--- a/ingestors/nuget.go
+++ b/ingestors/nuget.go
@@ -120,11 +120,11 @@ func (ingestor *Nuget) getPage(url string) ([]data.PackageVersion, error) {
 			results = append(
 				results,
 				data.PackageVersion{
-					Platform:  "nuget",
-					Name:      pkg.Name,
-					Version:   pkg.Version,
-					CreatedAt: pkg.CommitTime,
-					Lag:       time.Since(pkg.CommitTime),
+					Platform:     "nuget",
+					Name:         pkg.Name,
+					Version:      pkg.Version,
+					CreatedAt:    pkg.CommitTime,
+					DiscoveryLag: time.Since(pkg.CommitTime),
 				},
 			)
 		}

--- a/ingestors/nuget.go
+++ b/ingestors/nuget.go
@@ -124,7 +124,7 @@ func (ingestor *Nuget) getPage(url string) ([]data.PackageVersion, error) {
 					Name:      pkg.Name,
 					Version:   pkg.Version,
 					CreatedAt: pkg.CommitTime,
-					Lag:       time.Now().Sub(pkg.CommitTime),
+					Lag:       time.Since(pkg.CommitTime),
 				},
 			)
 		}

--- a/ingestors/packagist.go
+++ b/ingestors/packagist.go
@@ -50,11 +50,11 @@ func (ingestor *Packagist) ingestURL(feedUrl string) []data.PackageVersion {
 		nameAndVersion := strings.SplitN(item.GUID, " ", 2)
 		results = append(results,
 			data.PackageVersion{
-				Platform:  ingestor.Name(),
-				Name:      nameAndVersion[0],
-				Version:   nameAndVersion[1],
-				CreatedAt: *item.PublishedParsed,
-				Lag:       time.Since(*item.PublishedParsed),
+				Platform:     ingestor.Name(),
+				Name:         nameAndVersion[0],
+				Version:      nameAndVersion[1],
+				CreatedAt:    *item.PublishedParsed,
+				DiscoveryLag: time.Since(*item.PublishedParsed),
 			})
 	}
 

--- a/ingestors/packagist.go
+++ b/ingestors/packagist.go
@@ -54,7 +54,7 @@ func (ingestor *Packagist) ingestURL(feedUrl string) []data.PackageVersion {
 				Name:      nameAndVersion[0],
 				Version:   nameAndVersion[1],
 				CreatedAt: *item.PublishedParsed,
-				Lag:       time.Now().Sub(*item.PublishedParsed),
+				Lag:       time.Since(*item.PublishedParsed),
 			})
 	}
 

--- a/ingestors/packagist.go
+++ b/ingestors/packagist.go
@@ -54,6 +54,7 @@ func (ingestor *Packagist) ingestURL(feedUrl string) []data.PackageVersion {
 				Name:      nameAndVersion[0],
 				Version:   nameAndVersion[1],
 				CreatedAt: *item.PublishedParsed,
+				Lag:       time.Now().Sub(*item.PublishedParsed),
 			})
 	}
 

--- a/ingestors/pypi_rss.go
+++ b/ingestors/pypi_rss.go
@@ -60,7 +60,7 @@ func (ingestor *PyPiRss) getUpdates() []data.PackageVersion {
 				Name:      nameAndVersion[0],
 				Version:   nameAndVersion[1],
 				CreatedAt: *item.PublishedParsed,
-				Lag:       time.Now().Sub(*item.PublishedParsed),
+				Lag:       time.Since(*item.PublishedParsed),
 			})
 	}
 
@@ -124,7 +124,7 @@ func (ingestor *PyPiRss) getReleases(packageName string) []data.PackageVersion {
 				Name:      packageName,
 				Version:   item.Title,
 				CreatedAt: *item.PublishedParsed,
-				Lag:       time.Now().Sub(*item.PublishedParsed),
+				Lag:       time.Since(*item.PublishedParsed),
 			})
 	}
 

--- a/ingestors/pypi_rss.go
+++ b/ingestors/pypi_rss.go
@@ -60,6 +60,7 @@ func (ingestor *PyPiRss) getUpdates() []data.PackageVersion {
 				Name:      nameAndVersion[0],
 				Version:   nameAndVersion[1],
 				CreatedAt: *item.PublishedParsed,
+				Lag:       time.Now().Sub(*item.PublishedParsed),
 			})
 	}
 
@@ -123,6 +124,7 @@ func (ingestor *PyPiRss) getReleases(packageName string) []data.PackageVersion {
 				Name:      packageName,
 				Version:   item.Title,
 				CreatedAt: *item.PublishedParsed,
+				Lag:       time.Now().Sub(*item.PublishedParsed),
 			})
 	}
 

--- a/ingestors/pypi_rss.go
+++ b/ingestors/pypi_rss.go
@@ -56,11 +56,11 @@ func (ingestor *PyPiRss) getUpdates() []data.PackageVersion {
 		nameAndVersion := strings.SplitN(item.Title, " ", 2)
 		results = append(results,
 			data.PackageVersion{
-				Platform:  "pypi",
-				Name:      nameAndVersion[0],
-				Version:   nameAndVersion[1],
-				CreatedAt: *item.PublishedParsed,
-				Lag:       time.Since(*item.PublishedParsed),
+				Platform:     "pypi",
+				Name:         nameAndVersion[0],
+				Version:      nameAndVersion[1],
+				CreatedAt:    *item.PublishedParsed,
+				DiscoveryLag: time.Since(*item.PublishedParsed),
 			})
 	}
 
@@ -120,11 +120,11 @@ func (ingestor *PyPiRss) getReleases(packageName string) []data.PackageVersion {
 	for _, item := range feed.Items {
 		results = append(results,
 			data.PackageVersion{
-				Platform:  "pypi",
-				Name:      packageName,
-				Version:   item.Title,
-				CreatedAt: *item.PublishedParsed,
-				Lag:       time.Since(*item.PublishedParsed),
+				Platform:     "pypi",
+				Name:         packageName,
+				Version:      item.Title,
+				CreatedAt:    *item.PublishedParsed,
+				DiscoveryLag: time.Since(*item.PublishedParsed),
 			})
 	}
 

--- a/ingestors/pypi_xml_rpc.go
+++ b/ingestors/pypi_xml_rpc.go
@@ -29,10 +29,10 @@ func (ingestor *PyPiXmlRpc) Schedule() string {
 	return "@every 5m"
 }
 
-// changelog(since, with_ids=False)
-// 	Retrieve a list of [name, version, timestamp, action] since the given since. All since timestamps
-//  are UTC values. The argument is a UTC integer seconds since the epoch (e.g., the timestamp method
-//  to a datetime.datetime object).
+// Retrieve a list of [name, version, timestamp, action] since the given since. All since timestamps
+// are UTC values. The argument is a UTC integer seconds since the epoch (e.g., the timestamp method
+// to a datetime.datetime object).
+// calls "changelog(since, with_ids=False)" RPC
 func (ingestor *PyPiXmlRpc) Ingest() []data.PackageVersion {
 	// An array of interface arrays. Each log entry contains:
 	// name(string), version(string), timestamp(int64), action(string)
@@ -64,12 +64,15 @@ func (ingestor *PyPiXmlRpc) Ingest() []data.PackageVersion {
 		//fmt.Printf("%s %s %v %s\n", log[0], log[1], log[2], log[3])
 		switch log[3].(string) {
 		case "new release", "yank release", "remove release":
+			createdAt := time.Unix(log[2].(int64), 0)
+			lag := time.Now().Sub(createdAt)
 			results = append(results,
 				data.PackageVersion{
 					Platform:  "pypi",
 					Name:      log[0].(string),
 					Version:   log[1].(string),
-					CreatedAt: time.Unix(log[2].(int64), 0),
+					CreatedAt: createdAt,
+					Lag:       lag,
 				})
 		}
 	}

--- a/ingestors/pypi_xml_rpc.go
+++ b/ingestors/pypi_xml_rpc.go
@@ -65,7 +65,7 @@ func (ingestor *PyPiXmlRpc) Ingest() []data.PackageVersion {
 		switch log[3].(string) {
 		case "new release", "yank release", "remove release":
 			createdAt := time.Unix(log[2].(int64), 0)
-			lag := time.Now().Sub(createdAt)
+			lag := time.Since(createdAt)
 			results = append(results,
 				data.PackageVersion{
 					Platform:  "pypi",

--- a/ingestors/pypi_xml_rpc.go
+++ b/ingestors/pypi_xml_rpc.go
@@ -65,14 +65,14 @@ func (ingestor *PyPiXmlRpc) Ingest() []data.PackageVersion {
 		switch log[3].(string) {
 		case "new release", "yank release", "remove release":
 			createdAt := time.Unix(log[2].(int64), 0)
-			lag := time.Since(createdAt)
+			discoveryLag := time.Since(createdAt)
 			results = append(results,
 				data.PackageVersion{
-					Platform:  "pypi",
-					Name:      log[0].(string),
-					Version:   log[1].(string),
-					CreatedAt: createdAt,
-					Lag:       lag,
+					Platform:     "pypi",
+					Name:         log[0].(string),
+					Version:      log[1].(string),
+					CreatedAt:    createdAt,
+					DiscoveryLag: discoveryLag,
 				})
 		}
 	}

--- a/ingestors/rubygems.go
+++ b/ingestors/rubygems.go
@@ -56,15 +56,15 @@ func (ingestor *RubyGems) ingestURL(url string) []data.PackageVersion {
 		version, _ := jsonparser.GetString(value, "version")
 		createdAt, _ := jsonparser.GetString(value, "version_created_at")
 		createdAtTime, _ := time.Parse(time.RFC3339, createdAt)
-		lag := time.Since(createdAtTime)
+		discoveryLag := time.Since(createdAtTime)
 
 		results = append(results,
 			data.PackageVersion{
-				Platform:  "rubygems",
-				Name:      name,
-				Version:   version,
-				CreatedAt: createdAtTime,
-				Lag:       lag,
+				Platform:     "rubygems",
+				Name:         name,
+				Version:      version,
+				CreatedAt:    createdAtTime,
+				DiscoveryLag: discoveryLag,
 			})
 	})
 

--- a/ingestors/rubygems.go
+++ b/ingestors/rubygems.go
@@ -56,7 +56,7 @@ func (ingestor *RubyGems) ingestURL(url string) []data.PackageVersion {
 		version, _ := jsonparser.GetString(value, "version")
 		createdAt, _ := jsonparser.GetString(value, "version_created_at")
 		createdAtTime, _ := time.Parse(time.RFC3339, createdAt)
-		lag := time.Now().Sub(createdAtTime)
+		lag := time.Since(createdAtTime)
 
 		results = append(results,
 			data.PackageVersion{

--- a/ingestors/rubygems.go
+++ b/ingestors/rubygems.go
@@ -56,6 +56,7 @@ func (ingestor *RubyGems) ingestURL(url string) []data.PackageVersion {
 		version, _ := jsonparser.GetString(value, "version")
 		createdAt, _ := jsonparser.GetString(value, "version_created_at")
 		createdAtTime, _ := time.Parse(time.RFC3339, createdAt)
+		lag := time.Now().Sub(createdAtTime)
 
 		results = append(results,
 			data.PackageVersion{
@@ -63,6 +64,7 @@ func (ingestor *RubyGems) ingestURL(url string) []data.PackageVersion {
 				Name:      name,
 				Version:   version,
 				CreatedAt: createdAtTime,
+				Lag:       lag,
 			})
 	})
 

--- a/ingestors/rubygems.go
+++ b/ingestors/rubygems.go
@@ -1,7 +1,7 @@
 package ingestors
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -49,7 +49,7 @@ func (ingestor *RubyGems) ingestURL(url string) []data.PackageVersion {
 
 	defer response.Body.Close()
 
-	body, _ := ioutil.ReadAll(response.Body)
+	body, _ := io.ReadAll(response.Body)
 
 	_, err = jsonparser.ArrayEach(body, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		name, _ := jsonparser.GetString(value, "name")

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
@@ -124,7 +124,7 @@ func setupLogger() {
 	log.AddHook(hook)
 
 	// Send error-y logs to stderr and info-y logs to stdout
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	log.AddHook(&writer.Hook{
 		Writer: os.Stderr,
 		LogLevels: []log.Level{

--- a/publishers/logging_publisher.go
+++ b/publishers/logging_publisher.go
@@ -15,6 +15,7 @@ func (publisher *LoggingPublisher) Publish(packageVersion data.PackageVersion) {
 			"name":     packageVersion.Name,
 			"version":  packageVersion.Version,
 			"created":  packageVersion.CreatedAt,
+			"lag":      packageVersion.Lag.Milliseconds(),
 		}).
 		Info("Depper publish")
 }

--- a/publishers/logging_publisher.go
+++ b/publishers/logging_publisher.go
@@ -11,11 +11,11 @@ type LoggingPublisher struct{}
 func (publisher *LoggingPublisher) Publish(packageVersion data.PackageVersion) {
 	log.
 		WithFields(log.Fields{
-			"platform": packageVersion.Platform,
-			"name":     packageVersion.Name,
-			"version":  packageVersion.Version,
-			"created":  packageVersion.CreatedAt,
-			"lag":      packageVersion.Lag.Milliseconds(),
+			"platform":     packageVersion.Platform,
+			"name":         packageVersion.Name,
+			"version":      packageVersion.Version,
+			"created":      packageVersion.CreatedAt,
+			"discoveryLag": packageVersion.DiscoveryLag.Milliseconds(),
 		}).
 		Info("Depper publish")
 }


### PR DESCRIPTION
### Example

```time="2023-02-02T13:21:13-07:00" level="info" msg="Depper publish" created="2017-07-27 00:58:14.264 -0700 MST" discoveryLag="174226973683" name="org.springframework.boot:spring-boot-devtools-tests" platform="maven_springlibs" version="1.5.6.RELEASE"```

Also: some linting and go version bump.