### PR TITLE
Log rubygems feed error earlier so we have more diagnostic data.

### DIFF
--- a/ingestors/rubygems.go
+++ b/ingestors/rubygems.go
@@ -72,6 +72,10 @@ func (ingestor *RubyGems) ingestURL(url string) []data.PackageVersion {
 				DiscoveryLag: discoveryLag,
 			})
 	})
+	if err != nil {
+		// TODO: we can remove this log line once confirmed that the above one is working and more useful.
+		log.WithFields(log.Fields{"ingestor": "rubygems", "error": err}).Error()
+	}
 
 	return results
 }

--- a/ingestors/rubygems.go
+++ b/ingestors/rubygems.go
@@ -52,6 +52,11 @@ func (ingestor *RubyGems) ingestURL(url string) []data.PackageVersion {
 	body, _ := io.ReadAll(response.Body)
 
 	_, err = jsonparser.ArrayEach(body, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+		if err != nil {
+			log.WithFields(log.Fields{"ingestor": "rubygems", "error": err, "value": string(value), "dataType": dataType.String(), "offset": offset}).Error()
+			return
+		}
+
 		name, _ := jsonparser.GetString(value, "name")
 		version, _ := jsonparser.GetString(value, "version")
 		createdAt, _ := jsonparser.GetString(value, "version_created_at")
@@ -67,10 +72,6 @@ func (ingestor *RubyGems) ingestURL(url string) []data.PackageVersion {
 				DiscoveryLag: discoveryLag,
 			})
 	})
-
-	if err != nil {
-		log.WithFields(log.Fields{"ingestor": "rubygems", "error": err}).Error()
-	}
 
 	return results
 }


### PR DESCRIPTION
These errors come along from the rubygems ingestor sometimes. We don't have any idea what the feed response was in those cases, so this moves the error logging inside our line-by-line callback so we know where the parsing went wrong:

```
*errors.errorStringmain.go:76
Unknown value type

*errors.errorString Unknown value type 
    github.com/sirupsen/logrus@v1.9.0/entry.go:304 (*Entry).Log
    /app/ingestors/rubygems.go:72 (*RubyGems).ingestURL
    /app/ingestors/rubygems.go:32 (*RubyGems).Ingest
    main.go:76 (*Depper).registerIngestor.func1
    github.com/robfig/cron/v3@v3.0.1/cron.go:136 FuncJob.Run
    github.com/robfig/cron/v3@v3.0.1/cron.go:312 (*Cron).startJob.func1
```