### PR TITLE
change deprecated method

### DIFF
--- a/ingestors/pypi_xml_rpc.go
+++ b/ingestors/pypi_xml_rpc.go
@@ -124,7 +124,7 @@ func (ingestor *PyPiXmlRpc) Ingest() []data.PackageVersion {
 	client, _ := xmlrpc.NewClient(pyPiRpcServer, nil)
 	defer client.Close()
 
-	err = client.Call("changelog", int(since.Unix()), &response)
+	err = client.Call("changelog_since_serial", int(since.Unix()), &response)
 	if err != nil {
 		if strings.Contains(fmt.Sprint(err), "illegal character code") {
 			// If we encounter illegal characters in the XML, ignore this page and treat it like an empty response.


### PR DESCRIPTION
```
msg="Fault(-32500): ValueError: The changelog method has been deprecated, use changelog_since_serial instead." ingestor="pypiXmlRpc"
```