### PR TITLE
PyPiXmlRpc: update response handling to use serial instead of timestamp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run:
           command: go install github.com/jstemmer/go-junit-report@latest
       - run:
-          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.2
+          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
       - run:
           command: go get -v -t -d ./...
 

--- a/ingestors/pypi_xml_rpc.go
+++ b/ingestors/pypi_xml_rpc.go
@@ -6,15 +6,15 @@ Load latest releases from the PyPI XML-RPC endpoint
 (https://warehouse.pypa.io/api-reference/xml-rpc.html#changelog-since-with-ids-false)
 and return ingestion results.
 
-The XML-RPC endpoint is mostly deprecated. Methods that have to do with
-mirroring, like the "changelog" endpoint we're using, are still supported
-as of 2023-09-05.
+The XML-RPC endpoint is mostly deprecated. We previously used the "changelog" method,
+but it was deprecated so we switched to "changelog_since_serial" on 2023-12-08.
 
 This feed continually delivers new information on changes to the PyPI database.
 We're most concerned with actions that:
 
 * Add a release
 * Yank (remove from listings but still allow downloads) a release
+* Unyank (re-added to listings) a release
 * Remove (remove from listings and prevent downloads) a release
 
 Once we see one of these actions, we create an ingestion event for the release.
@@ -162,7 +162,7 @@ func (ingestor *PyPiXmlRpc) Ingest() []data.PackageVersion {
 		if strings.Contains(fmt.Sprint(err), "illegal character code") {
 			// If we encounter illegal characters in the XML, ignore this page and treat it like an empty response.
 			log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Error(err)
-			log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Info(fmt.Sprintf("Skipping page from serial %s", serial))
+			log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Info(fmt.Sprintf("Skipping page from serial %d", serial))
 			response = [][]any{}
 		} else {
 			log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Fatal(err)

--- a/ingestors/pypi_xml_rpc.go
+++ b/ingestors/pypi_xml_rpc.go
@@ -62,7 +62,7 @@ type PyPiXmlRpcResponse struct {
 // Return trhe if this response is an ingestable action
 func (response *PyPiXmlRpcResponse) IsIngestionAction() bool {
 	switch response.Action {
-	case "new release", "yank release", "remove release":
+	case "new release", "yank release", "remove release", "unyank release":
 		return true
 	}
 

--- a/ingestors/pypi_xml_rpc_test.go
+++ b/ingestors/pypi_xml_rpc_test.go
@@ -13,6 +13,7 @@ type ingestionTest struct {
 var ingestionTests = []ingestionTest{
 	{"new release", true},
 	{"yank release", true},
+	{"unyank release", true},
 	{"remove release", true},
 	{"something else", false},
 }
@@ -20,7 +21,7 @@ var ingestionTests = []ingestionTest{
 func TestPyPiXmlRpcResponse_IsIngestionAction(t *testing.T) {
 	for _, test := range ingestionTests {
 		response := PyPiXmlRpcResponse{
-			"what", "ever", 1, test.action,
+			"what", "ever", 1, test.action, 1234,
 		}
 
 		if response.IsIngestionAction() != test.expected {
@@ -41,7 +42,7 @@ func TestPyPiXmlRpcResponse_GetPackageVersion(t *testing.T) {
 	fiveSecondsAgo := now.Add(fiveSecondsAgoDuration)
 
 	response := PyPiXmlRpcResponse{
-		"name", "version", fiveSecondsAgo.Unix(), "whatever",
+		"name", "version", fiveSecondsAgo.Unix(), "whatever", 1235,
 	}
 
 	packageVersion := response.GetPackageVersion()
@@ -71,10 +72,10 @@ type logResponseTest struct {
 }
 
 var logResponsesFailures = []logResponseTest{
-	{[]any{nil, "1.0.0", int64(100), "action"}, "package name is not a string"},
-	{[]any{"name", nil, int64(100), "action"}, "version is not a string"},
-	{[]any{"name", "1.0.0", nil, "action"}, "created at date is not an int64 number"},
-	{[]any{"name", "1.0.0", int64(100), nil}, "action is not a string"},
+	{[]any{nil, "1.0.0", int64(100), "action", 1000}, "package name is not a string"},
+	{[]any{"name", nil, int64(100), "action", 1001}, "version is not a string"},
+	{[]any{"name", "1.0.0", nil, "action", 1002}, "created at date is not an int64 number"},
+	{[]any{"name", "1.0.0", int64(100), nil, 1003}, "action is not a string"},
 }
 
 func TestCreateResponseStruct_Failure(t *testing.T) {
@@ -87,7 +88,7 @@ func TestCreateResponseStruct_Failure(t *testing.T) {
 }
 
 func TestCreateResponseStruct_Success(t *testing.T) {
-	response, err := createResponseStruct([]any{"name", "1.0.0", int64(100), "action"})
+	response, err := createResponseStruct([]any{"name", "1.0.0", int64(100), "action", int64(1000)})
 
 	if err != nil {
 		t.Errorf("expected err to be nil, got %#v", err)
@@ -107,5 +108,9 @@ func TestCreateResponseStruct_Success(t *testing.T) {
 
 	if response.Action != "action" {
 		t.Errorf("expected action to equal %s, got %s", "action", response.Action)
+	}
+
+	if response.Serial != 1000 {
+		t.Errorf("expected serial to equal %d, got %d", 1000, response.Serial)
 	}
 }


### PR DESCRIPTION
previously the PyPiXmlRpc ingestor used the `changelog` endpoint, which accepted a timestamp int as an arg. But now we're using [`changelog_since_serial`, which takes a serial int as an arg](https://warehouse.pypa.io/api-reference/xml-rpc.html#changelog-since-serial-since-serial). The serial int is passed along with every event, so we can parse that and store it as the bookmark now, instead of the timestamp.

(followup to https://github.com/librariesio/depper/pull/74)

