### PR TITLE
Log Out Error Messages from Cargo API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@
 # vendor/
 
 /depper
+.idea/workspace.xml
+.idea/vcs.xml
+.idea/GitLink.xml
+.idea/depper.iml

--- a/ingestors/cargo.go
+++ b/ingestors/cargo.go
@@ -53,13 +53,16 @@ func (ingestor *Cargo) ingestURL(url string) []data.PackageVersion {
 			// we can concatenate the messages together to return in a Go Error object but log them out individually
 			var totalErrorMessage = ""
 
-			jsonparser.ArrayEach(value, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+			_, subErr = jsonparser.ArrayEach(value, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 				errorMessage, _ := jsonparser.GetString(value, "detail")
 				totalErrorMessage += "|" + errorMessage
 				log.WithFields(log.Fields{"ingestor": "cargo", "error": errorMessage}).Error()
 			})
 
-			subErr = errors.New(totalErrorMessage)
+			if subErr == nil {
+				subErr = errors.New(totalErrorMessage)
+			}
+
 		}
 
 		if string(key) == "just_updated" || string(key) == "new_crates" {

--- a/ingestors/cargo.go
+++ b/ingestors/cargo.go
@@ -1,6 +1,7 @@
 package ingestors
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"time"
@@ -46,6 +47,21 @@ func (ingestor *Cargo) ingestURL(url string) []data.PackageVersion {
 	body, _ := io.ReadAll(response.Body)
 	err = jsonparser.ObjectEach(body, func(key []byte, value []byte, dataType jsonparser.ValueType, offset int) error {
 		var subErr error
+
+		if string(key) == "errors" {
+			// there can be multiple errors returned based on the API response schema
+			// we can concatenate the messages together to return in a Go Error object but log them out individually
+			var totalErrorMessage = ""
+
+			jsonparser.ArrayEach(value, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+				errorMessage, _ := jsonparser.GetString(value, "detail")
+				totalErrorMessage += "|" + errorMessage
+				log.WithFields(log.Fields{"ingestor": "cargo", "error": errorMessage}).Error()
+			})
+
+			subErr = errors.New(totalErrorMessage)
+		}
+
 		if string(key) == "just_updated" || string(key) == "new_crates" {
 			_, subErr = jsonparser.ArrayEach(value, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 				name, _ := jsonparser.GetString(value, "name")


### PR DESCRIPTION
Cargo ingestion is currently broken but we aren't logging anything. Local investigation shows errors in the API response but those are hidden on production. This PR would add a handler for the `errors` key in the API response, log out each detail message, and return an Error object from the ingestor.