### PR TITLE
Fix broken Cargo ingestor

### DIFF
--- a/ingestors/cargo.go
+++ b/ingestors/cargo.go
@@ -36,7 +36,15 @@ func (ingestor *Cargo) Ingest() []data.PackageVersion {
 func (ingestor *Cargo) ingestURL(url string) []data.PackageVersion {
 	var results []data.PackageVersion
 
-	response, err := http.Get(url)
+    client := &http.Client{}
+    req, err := http.NewRequest("GET", url, nil)
+    if err != nil {
+		log.WithFields(log.Fields{"ingestor": "cargo", "error": err}).Error()
+		return results
+    }
+    req.Header.Set("User-Agent", "LibrariesDepper/1.0 (support@libraries.io)")
+    response, err := client.Do(req)
+
 	if err != nil {
 		log.WithFields(log.Fields{"ingestor": "cargo", "error": err}).Error()
 		return results

--- a/ingestors/cargo.go
+++ b/ingestors/cargo.go
@@ -42,7 +42,7 @@ func (ingestor *Cargo) ingestURL(url string) []data.PackageVersion {
 		log.WithFields(log.Fields{"ingestor": "cargo", "error": err}).Error()
 		return results
     }
-    req.Header.Set("User-Agent", "LibrariesDepper/1.0 (support@libraries.io)")
+    req.Header.Set("User-Agent", UserAgent)
     response, err := client.Do(req)
 
 	if err != nil {

--- a/ingestors/constants.go
+++ b/ingestors/constants.go
@@ -1,0 +1,3 @@
+package ingestors
+
+const UserAgent = "LibrariesDepper/1.0 (support@libraries.io)"


### PR DESCRIPTION
It looks like https://github.com/rust-lang/crates.io/blob/9c7302bdc16c6a4d917cf5929c4e6edd74a5da9a/src/middleware/block_traffic.rs#L45 made it so that they block requests based on headers and ip

https://crates.io/data-access#api suggests adding a useful user agent string, so adding it here.