### PR TITLE
go 1.22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: cimg/go:1.21
+      - image: cimg/go:1.22
     environment:
       TEST_RESULTS: /tmp/test-results # path to where test results will be saved
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.1-bullseye
+FROM golang:1.22.1-bullseye
 
 WORKDIR /app
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/librariesio/depper
 
-go 1.21
+go 1.22
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.0


### PR DESCRIPTION
nothing critical, just an update to get us on the newest version: https://go.dev/blog/go1.22