### PR TITLE
drupal ingestor is returning a 403, turn it off while we investigate

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,7 +68,9 @@ func (depper *Depper) registerIngestors() {
 	depper.registerIngestor(ingestors.NewCargo())
 	depper.registerIngestor(ingestors.NewNuget())
 	depper.registerIngestor(ingestors.NewPackagist())
-	depper.registerIngestor(ingestors.NewDrupal())
+// drupal is returning a 403 as of 2024-05-06. need to investigate but let's
+// not block other ingestion as we do
+//	depper.registerIngestor(ingestors.NewDrupal())
 	depper.registerIngestor(ingestors.NewPyPiRss())
 	depper.registerIngestor(ingestors.NewPyPiXmlRpc())
 	depper.registerIngestor(ingestors.NewConda(ingestors.CondaForge))


### PR DESCRIPTION
Rather than break the entire ingestion pipeline, let's just skip drupal for now