### PR TITLE
Add ingestors for cpan, hackage, pub, and hex

### DIFF
--- a/ingestors/cpan.go
+++ b/ingestors/cpan.go
@@ -1,0 +1,59 @@
+package ingestors
+
+import (
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/librariesio/depper/data"
+)
+
+const cpanSchedule = "*/5 * * * *"
+const cpanReleasesUrl = "https://metacpan.org/recent.rss"
+
+type CPAN struct {
+	LatestRun time.Time
+}
+
+func NewCPAN() *CPAN {
+	return &CPAN{}
+}
+
+func (ingestor *CPAN) Name() string {
+	return "cpan"
+}
+
+func (ingestor *CPAN) Schedule() string {
+	return cpanSchedule
+}
+
+func (ingestor *CPAN) Ingest() []data.PackageVersion {
+	packages := ingestor.ingestURL(cpanReleasesUrl)
+	ingestor.LatestRun = time.Now()
+	return packages
+}
+
+func (ingestor *CPAN) ingestURL(feedUrl string) []data.PackageVersion {
+	var results []data.PackageVersion
+
+	feed, err := depperGetFeed(feedUrl)
+	if err != nil {
+		log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Error(err)
+		return results
+	}
+
+	for _, item := range feed.Items {
+		pieces := strings.Split(item.Title, "-")
+		results = append(results,
+			data.PackageVersion{
+				Platform:     ingestor.Name(),
+				Name:         strings.Join(pieces[0:len(pieces)-1], "-"),
+				Version:      pieces[len(pieces)-1],
+				CreatedAt:    *item.PublishedParsed,
+				DiscoveryLag: time.Since(*item.PublishedParsed),
+			})
+	}
+
+	return results
+}

--- a/ingestors/hackage.go
+++ b/ingestors/hackage.go
@@ -1,0 +1,59 @@
+package ingestors
+
+import (
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/librariesio/depper/data"
+)
+
+const hackageSchedule = "*/5 * * * *"
+const hackageReleasesUrl = "https://hackage.haskell.org/packages/recent.rss"
+
+type hackage struct {
+	LatestRun time.Time
+}
+
+func NewHackage() *hackage {
+	return &hackage{}
+}
+
+func (ingestor *hackage) Name() string {
+	return "hackage"
+}
+
+func (ingestor *hackage) Schedule() string {
+	return hackageSchedule
+}
+
+func (ingestor *hackage) Ingest() []data.PackageVersion {
+	packages := ingestor.ingestURL(hackageReleasesUrl)
+	ingestor.LatestRun = time.Now()
+	return packages
+}
+
+func (ingestor *hackage) ingestURL(feedUrl string) []data.PackageVersion {
+	var results []data.PackageVersion
+
+	feed, err := depperGetFeed(feedUrl)
+	if err != nil {
+		log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Error(err)
+		return results
+	}
+
+	for _, item := range feed.Items {
+		nameAndVersion := strings.SplitN(item.Title, " ", 2)
+		results = append(results,
+			data.PackageVersion{
+				Platform:     ingestor.Name(),
+				Name:         nameAndVersion[0],
+				Version:      nameAndVersion[1],
+				CreatedAt:    *item.PublishedParsed,
+				DiscoveryLag: time.Since(*item.PublishedParsed),
+			})
+	}
+
+	return results
+}

--- a/ingestors/hex.go
+++ b/ingestors/hex.go
@@ -1,0 +1,71 @@
+package ingestors
+
+import (
+	"io"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/buger/jsonparser"
+	"github.com/librariesio/depper/data"
+)
+
+const hexSchedule = "*/5 * * * *"
+const hexPackagesUrl = "https://hex.pm/api/packages?sort=updated_at"
+
+type hex struct {
+	LatestRun time.Time
+}
+
+func NewHex() *hex {
+	return &hex{}
+}
+
+func (ingestor *hex) Schedule() string {
+	return hexSchedule
+}
+
+func (ingestor *hex) Ingest() []data.PackageVersion {
+	var results []data.PackageVersion
+
+	response, err := depperGetUrl(hexPackagesUrl)
+	if err != nil {
+		log.WithFields(log.Fields{"ingestor": "hex", "error": err}).Error()
+		return results
+	}
+
+	defer response.Body.Close()
+
+	body, _ := io.ReadAll(response.Body)
+
+	_, err = jsonparser.ArrayEach(
+		body,
+		func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+			if err != nil {
+				log.WithFields(log.Fields{"ingestor": "hex", "error": err, "value": string(value), "dataType": dataType.String(), "offset": offset}).Error()
+				return
+			}
+			name, _ := jsonparser.GetString(value, "name")
+			updatedAt, _ := jsonparser.GetString(value, "updated_at")
+			version, _ := jsonparser.GetString(value, "latest_version")
+			updatedAtTime, _ := time.Parse(time.RFC3339, updatedAt)
+
+			discoveryLag := time.Since(updatedAtTime)
+			results = append(results,
+				data.PackageVersion{
+					Platform:     "hex",
+					Name:         name,
+					Version:      version,
+					CreatedAt:    updatedAtTime,
+					DiscoveryLag: discoveryLag,
+				})
+		},
+	)
+	if err != nil {
+		log.WithFields(log.Fields{"ingestor": "hex", "error": err}).Error()
+	}
+
+	ingestor.LatestRun = time.Now()
+
+	return results
+}

--- a/ingestors/pub.go
+++ b/ingestors/pub.go
@@ -1,0 +1,60 @@
+package ingestors
+
+import (
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/librariesio/depper/data"
+)
+
+const pubSchedule = "*/5 * * * *"
+const pubReleasesUrl = "https://pub.dartlang.org/feed.atom"
+
+type pub struct {
+	LatestRun time.Time
+}
+
+func NewPub() *pub {
+	return &pub{}
+}
+
+func (ingestor *pub) Name() string {
+	return "pub"
+}
+
+func (ingestor *pub) Schedule() string {
+	return pubSchedule
+}
+
+func (ingestor *pub) Ingest() []data.PackageVersion {
+	packages := ingestor.ingestURL(pubReleasesUrl)
+	ingestor.LatestRun = time.Now()
+	return packages
+}
+
+func (ingestor *pub) ingestURL(feedUrl string) []data.PackageVersion {
+	var results []data.PackageVersion
+
+	feed, err := depperGetFeed(feedUrl)
+	if err != nil {
+		log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Error(err)
+		return results
+	}
+
+	for _, item := range feed.Items {
+		// version of name is the title, for example v0.0.2 of foobar_flutter
+		nameAndVersion := strings.SplitN(item.Title, " ", 3)
+		results = append(results,
+			data.PackageVersion{
+				Platform:     ingestor.Name(),
+				Name:         nameAndVersion[2],
+				Version:      strings.TrimLeft(nameAndVersion[0], "v"),
+				CreatedAt:    *item.UpdatedParsed,
+				DiscoveryLag: time.Since(*item.UpdatedParsed),
+			})
+	}
+
+	return results
+}

--- a/main.go
+++ b/main.go
@@ -74,9 +74,13 @@ func (depper *Depper) registerIngestors() {
 	depper.registerIngestor(ingestors.NewCargo())
 	depper.registerIngestor(ingestors.NewNuget())
 	depper.registerIngestor(ingestors.NewPackagist())
-// drupal is returning a 403 as of 2024-05-06. need to investigate but let's
-// not block other ingestion as we do
-//	depper.registerIngestor(ingestors.NewDrupal())
+	depper.registerIngestor(ingestors.NewCPAN())
+	depper.registerIngestor(ingestors.NewHex())
+	depper.registerIngestor(ingestors.NewHackage())
+	depper.registerIngestor(ingestors.NewPub())
+	// drupal is returning a 403 as of 2024-05-06. need to investigate but let's
+	// not block other ingestion as we do
+	//	depper.registerIngestor(ingestors.NewDrupal())
 	depper.registerIngestor(ingestors.NewPyPiRss())
 	depper.registerIngestor(ingestors.NewPyPiXmlRpc())
 	depper.registerIngestor(ingestors.NewConda(ingestors.CondaForge))


### PR DESCRIPTION
Final ecosystems from dispatch. Note that I shifted CPAN to use their RSS feed as it should be lighterweight than calling their elasticsearch endpoint.