### PR TITLE
Go ingestor changes

### DIFF
--- a/ingestors/go.go
+++ b/ingestors/go.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/mod/module"
 
 	"github.com/buger/jsonparser"
 	"github.com/librariesio/depper/data"
@@ -51,10 +50,15 @@ func (ingestor *Go) Ingest() []data.PackageVersion {
 		createdAt, _ := jsonparser.GetString(scanner.Bytes(), "Timestamp")
 		createdAtTime, _ := time.Parse(time.RFC3339, createdAt)
 
+		// TODO: undoing this change from 2022 and monitoring it. Pseudoversions can
+		// be used legitimately by other packages, so let's monitor the traffic and
+		// see if it's not too noisy.
+		//
 		// Avoid publishing pseudo-versions, which are revisions for which no semver tag exists.
-		if module.IsPseudoVersion(version) {
-			continue
-		}
+		// if module.IsPseudoVersion(version) {
+		// 	continue
+		// }
+
 		discoveryLag := time.Since(createdAtTime)
 
 		results = append(results,

--- a/ingestors/go.go
+++ b/ingestors/go.go
@@ -27,10 +27,23 @@ func (ingestor *Go) Schedule() string {
 	return goSchedule
 }
 
+func (ingestor *Go) Name() string {
+	return "go"
+}
+
 func (ingestor *Go) Ingest() []data.PackageVersion {
-	// Currently the index only shows the last <=2000 package version releases from the date given. (https://proxy.golang.org/)
-	oneDayAgo := url.QueryEscape(time.Now().AddDate(0, 0, -1).Format(time.RFC3339))
-	url := fmt.Sprintf("%s?since=%s&limit=2000", goIndexUrl, oneDayAgo)
+	bookmarkTime, err := getBookmarkTime(ingestor, time.Now().AddDate(0, 0, -1)) // fallback to 1 day ago
+	if err != nil {
+		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Fatal()
+	}
+
+	// Currently the index only shows the last <=2000 package release from the
+	// date given. (https://proxy.golang.org/)
+	url := fmt.Sprintf(
+		"%s?since=%s&limit=2000",
+		goIndexUrl,
+		url.QueryEscape(bookmarkTime.Format(time.RFC3339)),
+	)
 
 	var results []data.PackageVersion
 
@@ -69,7 +82,16 @@ func (ingestor *Go) Ingest() []data.PackageVersion {
 				CreatedAt:    createdAtTime,
 				DiscoveryLag: discoveryLag,
 			})
+
+		if createdAtTime.After(bookmarkTime) {
+			bookmarkTime = createdAtTime
+		}
 	}
+
+	if _, err := setBookmarkTime(ingestor, bookmarkTime); err != nil {
+		log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Fatal(err)
+	}
+
 	if err := scanner.Err(); err != nil {
 		log.WithFields(log.Fields{"ingestor": "go", "error": err}).Error()
 	}


### PR DESCRIPTION
* Go ingestor:
  * add persisted bookmarking
    * previously, we would use "1 day ago" as the in-memory bookmark, whenever Depper restarts. But we currently need to do a backfill, so now's a good time to add persisted bookmarks (based on the "Timestamp" we get back from index.golang.org)
  * start logging pseudoversions again
    * these were disabled in 2022 before a lot of our Go code was cleaned up and wrangled: https://github.com/librariesio/depper/pull/57 ... but it's quite common for v0 Go Modules to be required from other packages, so Libraries needs to know about packages that only have pseudoversions. For example, here's a library that's required by another OSS package but doesn't have v1+ versions, as of writing: https://pkg.go.dev/github.com/charmbracelet/x/exp/golden@v0.0.0-20250107110353-48b574af22a5?tab=versions
