### PR TITLE
Update linter to latest, and add a doc.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run:
           command: go install github.com/jstemmer/go-junit-report@latest
       - run:
-          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.57.2
+          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.63.4
       - run:
           command: go get -v -t -d ./...
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ Depper has to know where to pick up once it restarts, so there are several metho
 
 `go test -v ./...`
 
+## Running the Linter
+
+You'll need the same version of our linter as CI, so reference the `".circleci/config.yml"` for the installation command.
+
+`golangci-lint run`: this will run the linter.
+
+`golangci-lint run --fix`: this will run the linter and autofix any autofix-able linter errors.
+
 ## Deploying
 
 1. merge PR into `main` branch


### PR DESCRIPTION
* `golangci-lint` 1.57.2 ~> 1.63.4
* add lint instructions to README

this version of the linter adds more support for autofixing (35 linters support it in total now)