### PR TITLE
DD spans: include "name" tag 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ Depper is an ingestor of package releases from multiple ecosystems (each ecosyst
 
 When new package releases are found, they are pushed to a shared redis queue for [Libraries.io](https://libraries.io) to process.
 
-## Ingestor Types
+## Types of Ingestors
 
-* `ingestors.Ingestor`: these are scheduled to ingest new versions at specific intervals (`ingestor.Schedule()`).
+Ingestors must satisfy one of these interfaces:
+
+* `ingestors.PollingIngestor`: these are scheduled to ingest new versions at specific intervals (`ingestor.Schedule()`).
 * `ingestors.StreamingIngestor`: these are always running in a goroutine, ingesting new releases via a channel
 
 ## Ingestor Cursor Patterns

--- a/ingestors/bookmarks.go
+++ b/ingestors/bookmarks.go
@@ -9,8 +9,8 @@ import (
 )
 
 // Use to set a string bookmark for an ingestor
-func setBookmark(namer Namer, bookmark string) (string, error) {
-	key := bookmarkKey(namer)
+func setBookmark(ingestor Ingestor, bookmark string) (string, error) {
+	key := bookmarkKey(ingestor)
 
 	err := redis.Client.Set(context.Background(), key, bookmark, 0).Err()
 	if err != nil {
@@ -21,8 +21,8 @@ func setBookmark(namer Namer, bookmark string) (string, error) {
 }
 
 // Use to set a datetime bookmark time for an ingestor
-func setBookmarkTime(namer Namer, bookmarkTime time.Time) (time.Time, error) {
-	if _, err := setBookmark(namer, bookmarkTime.Format(time.RFC3339)); err != nil {
+func setBookmarkTime(ingestor Ingestor, bookmarkTime time.Time) (time.Time, error) {
+	if _, err := setBookmark(ingestor, bookmarkTime.Format(time.RFC3339)); err != nil {
 		return bookmarkTime, err
 	}
 
@@ -30,8 +30,8 @@ func setBookmarkTime(namer Namer, bookmarkTime time.Time) (time.Time, error) {
 }
 
 // Use to get a string bookmark for an ingestor
-func getBookmark(namer Namer, defaultValue string) (string, error) {
-	val, err := redis.Client.Get(context.Background(), bookmarkKey(namer)).Result()
+func getBookmark(ingestor Ingestor, defaultValue string) (string, error) {
+	val, err := redis.Client.Get(context.Background(), bookmarkKey(ingestor)).Result()
 	if err == redis.Nil {
 		return defaultValue, nil
 	} else if err != nil {
@@ -42,13 +42,13 @@ func getBookmark(namer Namer, defaultValue string) (string, error) {
 }
 
 // Use to get a bookmark time for an ingestor
-func getBookmarkTime(namer Namer, defaultValue time.Time) (time.Time, error) {
-	result, err := getBookmark(namer, defaultValue.Format(time.RFC3339))
+func getBookmarkTime(ingestor Ingestor, defaultValue time.Time) (time.Time, error) {
+	result, err := getBookmark(ingestor, defaultValue.Format(time.RFC3339))
 	parsed, _ := time.Parse(time.RFC3339, result)
 
 	return parsed, err
 }
 
-func bookmarkKey(namer Namer) string {
-	return fmt.Sprintf("depper:bookmark:%s", namer.Name())
+func bookmarkKey(ingestor Ingestor) string {
+	return fmt.Sprintf("depper:bookmark:%s", ingestor.Name())
 }

--- a/ingestors/cargo.go
+++ b/ingestors/cargo.go
@@ -22,6 +22,10 @@ func NewCargo() *Cargo {
 	return &Cargo{}
 }
 
+func (ingestor *Cargo) Name() string {
+	return "cargo"
+}
+
 func (ingestor *Cargo) Schedule() string {
 	return cargoSchedule
 }

--- a/ingestors/cargo.go
+++ b/ingestors/cargo.go
@@ -41,7 +41,7 @@ func (ingestor *Cargo) ingestURL(url string) []data.PackageVersion {
 
 	response, err := depperGetUrl(url)
 	if err != nil {
-		log.WithFields(log.Fields{"ingestor": "cargo", "error": err}).Error()
+		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error()
 		return results
 	}
 
@@ -59,7 +59,7 @@ func (ingestor *Cargo) ingestURL(url string) []data.PackageVersion {
 			_, subErr = jsonparser.ArrayEach(value, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 				errorMessage, _ := jsonparser.GetString(value, "detail")
 				totalErrorMessage += "|" + errorMessage
-				log.WithFields(log.Fields{"ingestor": "cargo", "error": errorMessage}).Error()
+				log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": errorMessage}).Error()
 			})
 
 			if subErr == nil {
@@ -92,7 +92,7 @@ func (ingestor *Cargo) ingestURL(url string) []data.PackageVersion {
 	})
 
 	if err != nil {
-		log.WithFields(log.Fields{"ingestor": "cargo", "error": err}).Error()
+		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error()
 	}
 
 	return results

--- a/ingestors/elm.go
+++ b/ingestors/elm.go
@@ -42,7 +42,7 @@ func (ingestor *Elm) ingestURL(feedUrl string) []data.PackageVersion {
 	feed, err := depperGetFeed(feedUrl)
 
 	if err != nil {
-		log.WithFields(log.Fields{"ingestor": "elm"}).Error(err)
+		log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Error(err)
 		return results
 	}
 	for _, item := range feed.Items {

--- a/ingestors/elm.go
+++ b/ingestors/elm.go
@@ -22,6 +22,10 @@ func NewElm() *Elm {
 	return &Elm{}
 }
 
+func (ingestor *Elm) Name() string {
+	return "elm"
+}
+
 func (ingestor *Elm) Schedule() string {
 	return elmSchedule
 }

--- a/ingestors/go.go
+++ b/ingestors/go.go
@@ -49,7 +49,7 @@ func (ingestor *Go) Ingest() []data.PackageVersion {
 
 	response, err := depperGetUrl(url)
 	if err != nil {
-		log.WithFields(log.Fields{"ingestor": "go", "error": err}).Error()
+		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error()
 		return results
 	}
 
@@ -93,7 +93,7 @@ func (ingestor *Go) Ingest() []data.PackageVersion {
 	}
 
 	if err := scanner.Err(); err != nil {
-		log.WithFields(log.Fields{"ingestor": "go", "error": err}).Error()
+		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error()
 	}
 
 	ingestor.LatestRun = time.Now()

--- a/ingestors/hackage.go
+++ b/ingestors/hackage.go
@@ -12,29 +12,29 @@ import (
 const hackageSchedule = "*/5 * * * *"
 const hackageReleasesUrl = "https://hackage.haskell.org/packages/recent.rss"
 
-type hackage struct {
+type Hackage struct {
 	LatestRun time.Time
 }
 
-func NewHackage() *hackage {
-	return &hackage{}
+func NewHackage() *Hackage {
+	return &Hackage{}
 }
 
-func (ingestor *hackage) Name() string {
+func (ingestor *Hackage) Name() string {
 	return "hackage"
 }
 
-func (ingestor *hackage) Schedule() string {
+func (ingestor *Hackage) Schedule() string {
 	return hackageSchedule
 }
 
-func (ingestor *hackage) Ingest() []data.PackageVersion {
+func (ingestor *Hackage) Ingest() []data.PackageVersion {
 	packages := ingestor.ingestURL(hackageReleasesUrl)
 	ingestor.LatestRun = time.Now()
 	return packages
 }
 
-func (ingestor *hackage) ingestURL(feedUrl string) []data.PackageVersion {
+func (ingestor *Hackage) ingestURL(feedUrl string) []data.PackageVersion {
 	var results []data.PackageVersion
 
 	feed, err := depperGetFeed(feedUrl)

--- a/ingestors/hex.go
+++ b/ingestors/hex.go
@@ -21,6 +21,10 @@ func NewHex() *hex {
 	return &hex{}
 }
 
+func (ingestor *hex) Name() string {
+	return "hex"
+}
+
 func (ingestor *hex) Schedule() string {
 	return hexSchedule
 }

--- a/ingestors/hex.go
+++ b/ingestors/hex.go
@@ -34,7 +34,7 @@ func (ingestor *Hex) Ingest() []data.PackageVersion {
 
 	response, err := depperGetUrl(hexPackagesUrl)
 	if err != nil {
-		log.WithFields(log.Fields{"ingestor": "hex", "error": err}).Error()
+		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error()
 		return results
 	}
 
@@ -46,7 +46,7 @@ func (ingestor *Hex) Ingest() []data.PackageVersion {
 		body,
 		func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 			if err != nil {
-				log.WithFields(log.Fields{"ingestor": "hex", "error": err, "value": string(value), "dataType": dataType.String(), "offset": offset}).Error()
+				log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err, "value": string(value), "dataType": dataType.String(), "offset": offset}).Error()
 				return
 			}
 			name, _ := jsonparser.GetString(value, "name")
@@ -66,7 +66,7 @@ func (ingestor *Hex) Ingest() []data.PackageVersion {
 		},
 	)
 	if err != nil {
-		log.WithFields(log.Fields{"ingestor": "hex", "error": err}).Error()
+		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error()
 	}
 
 	ingestor.LatestRun = time.Now()

--- a/ingestors/hex.go
+++ b/ingestors/hex.go
@@ -13,23 +13,23 @@ import (
 const hexSchedule = "*/5 * * * *"
 const hexPackagesUrl = "https://hex.pm/api/packages?sort=updated_at"
 
-type hex struct {
+type Hex struct {
 	LatestRun time.Time
 }
 
-func NewHex() *hex {
-	return &hex{}
+func NewHex() *Hex {
+	return &Hex{}
 }
 
-func (ingestor *hex) Name() string {
+func (ingestor *Hex) Name() string {
 	return "hex"
 }
 
-func (ingestor *hex) Schedule() string {
+func (ingestor *Hex) Schedule() string {
 	return hexSchedule
 }
 
-func (ingestor *hex) Ingest() []data.PackageVersion {
+func (ingestor *Hex) Ingest() []data.PackageVersion {
 	var results []data.PackageVersion
 
 	response, err := depperGetUrl(hexPackagesUrl)

--- a/ingestors/interfaces.go
+++ b/ingestors/interfaces.go
@@ -6,9 +6,15 @@ import (
 	"github.com/librariesio/depper/data"
 )
 
+type Ingestor interface {
+	Name() string
+}
+
 // Regular ingestors provide an API we can poll for changes. This polling
 // is done on a regular schedule.
-type Ingestor interface {
+type PollingIngestor interface {
+	Ingestor
+
 	Schedule() string
 	Ingest() []data.PackageVersion
 }
@@ -18,13 +24,11 @@ type Ingestor interface {
 // CouchDB API endpoint from which we can continually pull new
 // package data.
 type StreamingIngestor interface {
+	Ingestor
+
 	Ingest(chan data.PackageVersion)
 }
 
 type TTLer interface {
 	TTL() time.Duration
-}
-
-type Namer interface {
-	Name() string
 }

--- a/ingestors/npm.go
+++ b/ingestors/npm.go
@@ -60,14 +60,14 @@ func (ingestor *NPM) Name() string {
 func (ingestor *NPM) Ingest(results chan data.PackageVersion) {
 	since, err := getBookmark(ingestor, "now")
 	if err != nil {
-		log.WithFields(log.Fields{"ingestor": "npm"}).Fatal(err)
+		log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Fatal(err)
 	}
 
 	options := getOptionsForChangesFeed(since)
 	couchDb := ingestor.couchClient.DB(NPMRegistryDatabase)
 	changes := couchDb.Changes(context.Background(), options)
 	if err = changes.Err(); err != nil {
-		log.WithFields(log.Fields{"ingestor": "npm"}).Fatal(err)
+		log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Fatal(err)
 	}
 	defer changes.Close()
 
@@ -100,17 +100,17 @@ func (ingestor *NPM) Ingest(results chan data.PackageVersion) {
 				}
 				since = changes.Seq()
 				if _, err := setBookmark(ingestor, since); err != nil {
-					log.WithFields(log.Fields{"ingestor": "npm"}).Fatal(err)
+					log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Fatal(err)
 				}
 			}
 		} else {
-			log.WithFields(log.Fields{"ingestor": "npm", "error": changes.Err()}).Error(fmt.Sprintf("Reconnecting in %d seconds.", RetryDelaySeconds))
+			log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": changes.Err()}).Error(fmt.Sprintf("Reconnecting in %d seconds.", RetryDelaySeconds))
 			time.Sleep(RetryDelaySeconds * time.Second)
 			couchDb = ingestor.couchClient.DB(NPMRegistryDatabase)
 			options := getOptionsForChangesFeed(since)
 			changes = couchDb.Changes(context.Background(), options)
 			if err = changes.Err(); err != nil {
-				log.WithFields(log.Fields{"ingestor": "npm"}).Fatal(err)
+				log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Fatal(err)
 			}
 		}
 	}

--- a/ingestors/nuget.go
+++ b/ingestors/nuget.go
@@ -42,6 +42,10 @@ func NewNuget() *Nuget {
 	return &Nuget{}
 }
 
+func (ingestor *Nuget) Name() string {
+	return "nuget"
+}
+
 func (ingestor *Nuget) Schedule() string {
 	return nugetSchedule
 }

--- a/ingestors/nuget.go
+++ b/ingestors/nuget.go
@@ -65,7 +65,7 @@ func (ingestor *Nuget) ingestURL(url string) []data.PackageVersion {
 
 	results, err := ingestor.getIndex(url)
 	if err != nil {
-		log.WithFields(log.Fields{"ingestor": "nuget", "error": err}).Error()
+		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error()
 	}
 
 	return results

--- a/ingestors/pub.go
+++ b/ingestors/pub.go
@@ -12,29 +12,29 @@ import (
 const pubSchedule = "*/5 * * * *"
 const pubReleasesUrl = "https://pub.dartlang.org/feed.atom"
 
-type pub struct {
+type Pub struct {
 	LatestRun time.Time
 }
 
-func NewPub() *pub {
-	return &pub{}
+func NewPub() *Pub {
+	return &Pub{}
 }
 
-func (ingestor *pub) Name() string {
+func (ingestor *Pub) Name() string {
 	return "pub"
 }
 
-func (ingestor *pub) Schedule() string {
+func (ingestor *Pub) Schedule() string {
 	return pubSchedule
 }
 
-func (ingestor *pub) Ingest() []data.PackageVersion {
+func (ingestor *Pub) Ingest() []data.PackageVersion {
 	packages := ingestor.ingestURL(pubReleasesUrl)
 	ingestor.LatestRun = time.Now()
 	return packages
 }
 
-func (ingestor *pub) ingestURL(feedUrl string) []data.PackageVersion {
+func (ingestor *Pub) ingestURL(feedUrl string) []data.PackageVersion {
 	var results []data.PackageVersion
 
 	feed, err := depperGetFeed(feedUrl)

--- a/ingestors/rubygems.go
+++ b/ingestors/rubygems.go
@@ -22,6 +22,10 @@ func NewRubyGems() *RubyGems {
 	return &RubyGems{}
 }
 
+func (ingestor *RubyGems) Name() string {
+	return "rubygems"
+}
+
 func (ingestor *RubyGems) Schedule() string {
 	return rubyGemsSchedule
 }

--- a/ingestors/rubygems.go
+++ b/ingestors/rubygems.go
@@ -46,7 +46,7 @@ func (ingestor *RubyGems) ingestURL(url string) []data.PackageVersion {
 
 	response, err := depperGetUrl(url)
 	if err != nil {
-		log.WithFields(log.Fields{"ingestor": "rubygems", "error": err}).Error()
+		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error()
 		return results
 	}
 
@@ -56,7 +56,15 @@ func (ingestor *RubyGems) ingestURL(url string) []data.PackageVersion {
 
 	_, err = jsonparser.ArrayEach(body, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if err != nil {
-			log.WithFields(log.Fields{"ingestor": "rubygems", "error": err, "value": string(value), "dataType": dataType.String(), "offset": offset}).Error()
+			log.WithFields(
+				log.Fields{
+					"ingestor": ingestor.Name(),
+					"error":    err,
+					"value":    string(value),
+					"dataType": dataType.String(),
+					"offset":   offset,
+				},
+			).Error()
 			return
 		}
 
@@ -77,7 +85,7 @@ func (ingestor *RubyGems) ingestURL(url string) []data.PackageVersion {
 	})
 	if err != nil {
 		// TODO: we can remove this log line once confirmed that the above one is working and more useful.
-		log.WithFields(log.Fields{"ingestor": "rubygems", "error": err}).Error()
+		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error()
 	}
 
 	return results

--- a/ingestors/rubygems.go
+++ b/ingestors/rubygems.go
@@ -54,7 +54,7 @@ func (ingestor *RubyGems) ingestURL(url string) []data.PackageVersion {
 
 	body, _ := io.ReadAll(response.Body)
 
-	_, err = jsonparser.ArrayEach(body, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+	_, _ = jsonparser.ArrayEach(body, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
 		if err != nil {
 			log.WithFields(
 				log.Fields{
@@ -83,10 +83,6 @@ func (ingestor *RubyGems) ingestURL(url string) []data.PackageVersion {
 				DiscoveryLag: discoveryLag,
 			})
 	})
-	if err != nil {
-		// TODO: we can remove this log line once confirmed that the above one is working and more useful.
-		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error()
-	}
 
 	return results
 }

--- a/main.go
+++ b/main.go
@@ -114,9 +114,12 @@ func (depper *Depper) registerIngestor(ingestor ingestors.PollingIngestor) {
 		packageVersions := ingestor.Ingest()
 		span.Finish()
 
+		span = tracer.StartSpan("publish")
+		span.SetTag("ingestor", ingestor.Name())
 		for _, packageVersion := range packageVersions {
 			depper.pipeline.Publish(ttl, packageVersion)
 		}
+		span.Finish()
 	}
 
 	_, err := c.AddFunc(ingestor.Schedule(), ingestAndPublish)

--- a/main.go
+++ b/main.go
@@ -110,8 +110,7 @@ func (depper *Depper) registerIngestor(ingestor ingestors.PollingIngestor) {
 		}
 
 		span := tracer.StartSpan("ingest")
-		// TODO: add ingestor name to span here
-		// span.SetTag(ingestor.Name())
+		span.SetTag("ingestor", ingestor.Name())
 		packageVersions := ingestor.Ingest()
 		span.Finish()
 

--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func (depper *Depper) registerIngestors() {
 	depper.registerIngestorStream(ingestors.NewNPM())
 }
 
-func (depper *Depper) registerIngestor(ingestor ingestors.Ingestor) {
+func (depper *Depper) registerIngestor(ingestor ingestors.PollingIngestor) {
 	c := cron.New()
 	ingestAndPublish := func() {
 		ttl := defaultTTL

--- a/publishers/sidekiq.go
+++ b/publishers/sidekiq.go
@@ -35,7 +35,7 @@ func randomHex(n int) string {
 	id := make([]byte, n)
 	_, err := io.ReadFull(rand.Reader, id)
 	if err != nil {
-		log.WithFields(log.Fields{"ingestor": "npm", "error": err})
+		log.WithFields(log.Fields{"error": err})
 	}
 	return hex.EncodeToString(id)
 }


### PR DESCRIPTION
The main goal here is to add better DD tracing insights, to make better guesses about what is SIGKILL'ing the process occasionally: 

* rename `Ingestor` interface to `PollingIngestor`, and rename `Namer` interface to be the new `Ingestor` interface
* define `Name()` functions on remaining ingestors that don't have it
* set an `"ingestor"` tag on DD spans, using the `Name()` functions
* wrap a new DD span around the the batch publishing of ingestor releases too