### PR TITLE
If NPM is unavailable when connecting, wait 5 minutes and try again.

### DIFF
--- a/ingestors/npm.go
+++ b/ingestors/npm.go
@@ -75,14 +75,13 @@ func (ingestor *NPM) Ingest(results chan data.PackageVersion) {
 	for {
 		couchDb = ingestor.couchClient.DB(NPMRegistryDatabase)
 		changes = couchDb.Changes(context.Background(), options)
+		defer changes.Close()
 		if err = changes.Err(); err != nil {
 			// If Changes() failed (e.g. NPM returns 503), then wait and try again.
-			log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).
-				Error(fmt.Sprintf("NPM unavailable, retrying in %d seconds.", ConnectRetryDelaySeconds))
+			log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error(fmt.Sprintf("NPM unavailable, retrying in %d seconds.", ConnectRetryDelaySeconds))
 			time.Sleep(ConnectRetryDelaySeconds * time.Second)
 		} else {
 			// If Changes() succeeded, continue on.
-			defer changes.Close()
 			break
 		}
 	}


### PR DESCRIPTION
### Problem

NPM's couchdb replica is currently down (503'ing), so depper is restarting every few minutes when the NPM ingestor tries to connect and does a fatal log:

<img width="545" alt="Screenshot 2025-01-22 at 2 12 35 PM" src="https://github.com/user-attachments/assets/7548598c-593f-45d5-9c9c-34bf966fa547" />

<img width="673" alt="Screenshot 2025-01-22 at 2 09 25 PM" src="https://github.com/user-attachments/assets/0c597644-9480-49c1-84ed-65e7ecb40238" />

### Solution

This prevents the restarts by adding an initial connection loop for NPM's ingestor. If the NPM service is down, we'll wait 5 minutes and try again:

<img width="1084" alt="Screenshot 2025-01-22 at 2 08 18 PM" src="https://github.com/user-attachments/assets/d24140e5-d83e-4c8d-a95c-e0d743bd17a9" />
