### PR TITLE
turn off cocoapods temporarily

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func createPipeline() *publishers.Pipeline {
 }
 
 func (depper *Depper) registerIngestors() {
-	depper.registerIngestor(ingestors.NewCocoaPods())
+//	depper.registerIngestor(ingestors.NewCocoaPods())
 	depper.registerIngestor(ingestors.NewRubyGems())
 	depper.registerIngestor(ingestors.NewElm())
 	depper.registerIngestor(ingestors.NewGo())


### PR DESCRIPTION
someone is doing supply chain research on cocoapods and publishing a ridiciulous number of releases which is overwhelming the cocoapods git repo