### PR TITLE
Support NPM replica changes.

### DIFF
--- a/data/package_version.go
+++ b/data/package_version.go
@@ -10,6 +10,7 @@ type PackageVersion struct {
 	Version      string
 	CreatedAt    time.Time
 	DiscoveryLag time.Duration // (time of depper discovery) - (creation time, as reported by repository)
+	Sequence     string        // arbitrary field for tracking the order of events and debugging
 }
 
 func MaxCreatedAt(packageVersions []PackageVersion) time.Time {

--- a/ingestors/cargo.go
+++ b/ingestors/cargo.go
@@ -39,7 +39,7 @@ func (ingestor *Cargo) Ingest() []data.PackageVersion {
 func (ingestor *Cargo) ingestURL(url string) []data.PackageVersion {
 	var results []data.PackageVersion
 
-	response, err := depperGetUrl(url)
+	response, err := depperGetUrl(url, map[string]string{})
 	if err != nil {
 		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error()
 		return results

--- a/ingestors/conda_parser.go
+++ b/ingestors/conda_parser.go
@@ -26,7 +26,7 @@ func NewCondaParser(url string, platform string) *CondaParser {
 func (parser *CondaParser) GetPackages(lastRun time.Time) ([]data.PackageVersion, error) {
 	var results []data.PackageVersion
 	for _, arch := range architectures {
-		response, err := depperGetUrl(fmt.Sprintf("%s/%s/repodata.json", parser.URL, arch))
+		response, err := depperGetUrl(fmt.Sprintf("%s/%s/repodata.json", parser.URL, arch), map[string]string{})
 		if err != nil {
 			return results, err
 		}

--- a/ingestors/drupal.go
+++ b/ingestors/drupal.go
@@ -105,7 +105,7 @@ func (ingestor *Drupal) getVersions(id string, bookmark time.Time) []data.Packag
 }
 
 func getHtmlDocument(url string) (*goquery.Document, error) {
-	res, err := depperGetUrl(url)
+	res, err := depperGetUrl(url, map[string]string{})
 	if err != nil {
 		return nil, err
 	}

--- a/ingestors/go.go
+++ b/ingestors/go.go
@@ -47,7 +47,7 @@ func (ingestor *Go) Ingest() []data.PackageVersion {
 
 	var results []data.PackageVersion
 
-	response, err := depperGetUrl(url)
+	response, err := depperGetUrl(url, map[string]string{})
 	if err != nil {
 		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error()
 		return results

--- a/ingestors/hex.go
+++ b/ingestors/hex.go
@@ -32,7 +32,7 @@ func (ingestor *Hex) Schedule() string {
 func (ingestor *Hex) Ingest() []data.PackageVersion {
 	var results []data.PackageVersion
 
-	response, err := depperGetUrl(hexPackagesUrl)
+	response, err := depperGetUrl(hexPackagesUrl, map[string]string{})
 	if err != nil {
 		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error()
 		return results

--- a/ingestors/http.go
+++ b/ingestors/http.go
@@ -8,13 +8,18 @@ import (
 	"github.com/mmcdole/gofeed"
 )
 
-func depperGetUrl(url string) (*http.Response, error) {
+func depperGetUrl(url string, headers map[string]string) (*http.Response, error) {
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
+
 	req.Header.Set("User-Agent", UserAgent)
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
 	return client.Do(req)
 }
 

--- a/ingestors/interfaces.go
+++ b/ingestors/interfaces.go
@@ -19,16 +19,6 @@ type PollingIngestor interface {
 	Ingest() []data.PackageVersion
 }
 
-// Streaming Ingestors continually pull new release information from a
-// persistent source. NPM is an example of this, as it provides a
-// CouchDB API endpoint from which we can continually pull new
-// package data.
-type StreamingIngestor interface {
-	Ingestor
-
-	Ingest(chan data.PackageVersion)
-}
-
 type TTLer interface {
 	TTL() time.Duration
 }

--- a/ingestors/maven_parser.go
+++ b/ingestors/maven_parser.go
@@ -29,7 +29,7 @@ func NewMavenParser(url string, platform string) *MavenParser {
 func (parser *MavenParser) GetPackages() ([]data.PackageVersion, error) {
 	var results []data.PackageVersion
 
-	response, err := depperGetUrl(parser.URL)
+	response, err := depperGetUrl(parser.URL, map[string]string{})
 	if err != nil {
 		return results, err
 	}

--- a/ingestors/npm.go
+++ b/ingestors/npm.go
@@ -1,154 +1,116 @@
 package ingestors
 
 import (
-	"context"
 	"fmt"
-	"time"
+	"io"
+	"strconv"
 
+	"github.com/buger/jsonparser"
 	log "github.com/sirupsen/logrus"
 
-	kivik "github.com/go-kivik/kivik/v4"
-
-	_ "github.com/go-kivik/kivik/v4/couchdb"
 	"github.com/librariesio/depper/data"
 )
 
-const NPMRegistryHostname = "https://replicate.npmjs.com"
-const NPMRegistryDatabase = "registry"
+const npmSchedule = "1-59 * * * *"
+const npmIndexUrl = "https://replicate.npmjs.com/registry/_changes"
 
-// Delay between attempts at initial connection to Changes() feed
-const ConnectRetryDelaySeconds = 60 * 5
+// Arbitrary sequence number from 5/20/2025, just to make sure we
+// don't fallback to "0". Via https://replicate.npmjs.com/registry/.
+const fallbackSequence = 42540679
+const perPage = 10000
 
-// Delay between attemps to fix broken connection to Changes() feed
-const ReconnectRetryDelaySeconds = 5
+// Limit number of pages per run in case we hit a bad sequence number / backfill.
+const maxResultsLength = 100000
 
 type NPM struct {
-	couchClient *kivik.Client
 }
 
 func NewNPM() *NPM {
-	return &NPM{couchClient: getCouchClient()}
+	return &NPM{}
 }
 
-// See https://github.com/npm/registry-follower-tutorial#moar-data-please
-type NPMChangeDoc struct {
-	ID       string `json:"_id"`
-	Rev      string `json:"_rev,omitempty"`
-	Name     string `json:"name"`
-	DistTags struct {
-		Latest string `json:"latest"`
-	} `json:"dist-tags"`
-	Time map[string]string `json:"time"`
+func (ingestor *NPM) Schedule() string {
+	return npmSchedule
 }
 
 func (ingestor *NPM) Name() string {
 	return "npm"
 }
 
-/**
- * NPM package updates are ingested from a continuous reading of a remote
- * CouchDB database at replicate.npmjs.com. CouchDB databases provide a Changes
- * feed that provide the changes since the last set of changes were published:
- * https://docs.couchbase.com/sync-gateway/current/changes-feed.html
- *
- * We connect to the CouchDB database and continually read for the next set
- * of changes to the database. Once we receive changes, we take the found releases
- * and add them to the processing queue. If no changes are available, we
- * reconnect to the database in a number of seconds and try again.
- *
- * Since this is based on detecting changes to the NPM database, it may be
- * possible for a client to miss out on changes for some reason. Libraries only
- * processes individual NPM versions delivered by depper, rather than reprocessing
- * the whole package, so in that case, Libraries may not know about that version
- * onless something triggers a full package resync on Libraries.
- */
-func (ingestor *NPM) Ingest(results chan data.PackageVersion) {
-	since, err := getBookmark(ingestor, "now")
-	if err != nil {
+func (ingestor *NPM) Ingest() []data.PackageVersion {
+	currentSequence := ingestor.getCurrentSequence()
+
+	var results []data.PackageVersion
+	for {
+		lastSequence, lastResults := ingestor.getPage(currentSequence)
+		if len(lastResults) == 0 || len(results) > maxResultsLength {
+			break
+		}
+		results = append(results, lastResults...)
+
+		if lastSequence > currentSequence {
+			currentSequence = lastSequence
+		}
+	}
+
+	if _, err := setBookmark(ingestor, strconv.FormatInt(currentSequence, 10)); err != nil {
 		log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Fatal(err)
 	}
 
-	options := getOptionsForChangesFeed(since)
-	var changes *kivik.Changes
-	var couchDb *kivik.DB
-
-	for {
-		couchDb = ingestor.couchClient.DB(NPMRegistryDatabase)
-		changes = couchDb.Changes(context.Background(), options)
-		defer changes.Close()
-		if err = changes.Err(); err != nil {
-			// If Changes() failed (e.g. NPM returns 503), then wait and try again.
-			log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error(fmt.Sprintf("NPM unavailable, retrying in %d seconds.", ConnectRetryDelaySeconds))
-			time.Sleep(ConnectRetryDelaySeconds * time.Second)
-		} else {
-			// If Changes() succeeded, continue on.
-			break
-		}
-	}
-
-	for {
-		if changes.Next() {
-			var doc NPMChangeDoc
-			if err := changes.ScanDoc(&doc); err != nil {
-				log.WithFields(log.Fields{"seq": changes.Seq(), "id": changes.ID()}).Fatal(err)
-			}
-			var latestVersion string
-			var latestTime time.Time
-			for k, v := range doc.Time {
-				if k != "modified" && k != "created" && len(v) > 0 {
-					if t, err := time.Parse(time.RFC3339, v); err == nil {
-						if t.After(latestTime) {
-							latestTime = t
-							latestVersion = k
-						}
-					}
-				}
-			}
-			if latestVersion != "" {
-				discoveryLag := time.Since(latestTime)
-				results <- data.PackageVersion{
-					Platform:     "npm",
-					Name:         doc.Name,
-					Version:      latestVersion,
-					CreatedAt:    latestTime,
-					DiscoveryLag: discoveryLag,
-				}
-				since = changes.Seq()
-				if _, err := setBookmark(ingestor, since); err != nil {
-					log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Fatal(err)
-				}
-			}
-		} else {
-			log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": changes.Err()}).Error(fmt.Sprintf("Reconnecting in %d seconds.", ReconnectRetryDelaySeconds))
-			time.Sleep(ReconnectRetryDelaySeconds * time.Second)
-			couchDb = ingestor.couchClient.DB(NPMRegistryDatabase)
-			options := getOptionsForChangesFeed(since)
-			changes = couchDb.Changes(context.Background(), options)
-			if err = changes.Err(); err != nil {
-				log.WithFields(log.Fields{"ingestor": ingestor.Name()}).Fatal(err)
-			}
-		}
-	}
+	return results
 }
 
-func getCouchClient() *kivik.Client {
-	kivikClient, err := kivik.New("couch", NPMRegistryHostname)
+func (ingestor *NPM) getPage(sequence int64) (int64, []data.PackageVersion) {
+	var results []data.PackageVersion
+
+	// The header enables the new API changes and can be removed May 29th, 2025:
+	// https://github.blog/changelog/2025-02-27-changes-and-deprecation-notice-for-npm-replication-apis/
+	response, err := depperGetUrl(
+		fmt.Sprintf("%s?since=%d&limit=%d", npmIndexUrl, sequence, perPage),
+		map[string]string{"npm-replication-opt-in": "true"},
+	)
 	if err != nil {
-		log.WithFields(log.Fields{"ingestor": "npm"}).Fatal(err)
+		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error()
+		return sequence, results
 	}
-	return kivikClient
+	defer response.Body.Close()
+
+	body, _ := io.ReadAll(response.Body)
+	sequenceList, _, _, _ := jsonparser.Get(body, "results")
+	_, _ = jsonparser.ArrayEach(sequenceList, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+		name, _ := jsonparser.GetString(value, "id")
+		seq, _ := jsonparser.GetInt(value, "seq")
+
+		// The new NPM feed only provides names and sequences, so we don't get Version, CreatedAt or DiscoveryLag.
+		results = append(results,
+			data.PackageVersion{
+				Platform: "npm",
+				Name:     name,
+				Sequence: strconv.FormatInt(seq, 10),
+			})
+	})
+	lastSequence, err := jsonparser.GetInt(body, "last_seq")
+	if err != nil {
+		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error()
+		lastSequence = sequence
+	}
+
+	return lastSequence, results
 }
 
-// Get a list of querystring params for the _changes endpoint.
-// Docs: https://docs.couchdb.org/en/3.2.0/api/database/changes.html
-func getOptionsForChangesFeed(since string) kivik.Option {
-	return kivik.Params(map[string]interface{}{
-		"feed":         "continuous",
-		"since":        since,
-		"include_docs": true,
-		// NB: previously with "timeout: 60000 * 2", we kept getting an internal error from npm, which surfaced as
-		// "stream error: stream ID 123; INTERNAL_ERROR". They showed up when there was no activity for 50 seconds,
-		// and we're not sure why. But setting a heartbeat ensures the connection stays open every 5 seconds via empty line.
-		"heartbeat": ReconnectRetryDelaySeconds * 1000,
-	})
+func (ingestor *NPM) getCurrentSequence() int64 {
+	bookmark, err := getBookmark(ingestor, "")
+	if err != nil {
+		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Fatal()
+	}
+
+	var currentSequence int64
+	if bookmark != "" {
+		currentSequence, _ = strconv.ParseInt(bookmark, 10, 64)
+	} else if currentSequence == 0 {
+		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "msg": fmt.Sprintf("No NPM bookmark saved, falling back to default sequence %d", fallbackSequence)}).Info()
+		currentSequence = fallbackSequence
+	}
+
+	return currentSequence
 }

--- a/ingestors/nuget.go
+++ b/ingestors/nuget.go
@@ -74,7 +74,7 @@ func (ingestor *Nuget) ingestURL(url string) []data.PackageVersion {
 func (ingestor *Nuget) getIndex(url string) ([]data.PackageVersion, error) {
 	var results []data.PackageVersion
 
-	response, err := depperGetUrl(url)
+	response, err := depperGetUrl(url, map[string]string{})
 	if err != nil {
 		return results, err
 	}
@@ -104,7 +104,7 @@ func (ingestor *Nuget) getIndex(url string) ([]data.PackageVersion, error) {
 func (ingestor *Nuget) getPage(url string) ([]data.PackageVersion, error) {
 	var results []data.PackageVersion
 
-	response, err := depperGetUrl(url)
+	response, err := depperGetUrl(url, map[string]string{})
 	if err != nil {
 		return []data.PackageVersion{}, err
 	}

--- a/ingestors/rubygems.go
+++ b/ingestors/rubygems.go
@@ -44,7 +44,7 @@ func (ingestor *RubyGems) Ingest() []data.PackageVersion {
 func (ingestor *RubyGems) ingestURL(url string) []data.PackageVersion {
 	var results []data.PackageVersion
 
-	response, err := depperGetUrl(url)
+	response, err := depperGetUrl(url, map[string]string{})
 	if err != nil {
 		log.WithFields(log.Fields{"ingestor": ingestor.Name(), "error": err}).Error()
 		return results

--- a/main.go
+++ b/main.go
@@ -96,8 +96,7 @@ func (depper *Depper) registerIngestors() {
 	depper.registerIngestor(ingestors.NewPyPiXmlRpc())
 	depper.registerIngestor(ingestors.NewConda(ingestors.CondaForge))
 	depper.registerIngestor(ingestors.NewConda(ingestors.CondaMain))
-
-	depper.registerIngestorStream(ingestors.NewNPM())
+	depper.registerIngestor(ingestors.NewNPM())
 }
 
 func (depper *Depper) registerIngestor(ingestor ingestors.PollingIngestor) {

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/librariesio/depper/data"
 	"github.com/librariesio/depper/ingestors"
 	"github.com/librariesio/depper/publishers"
 	"github.com/librariesio/depper/redis"
@@ -24,9 +23,8 @@ const defaultTTL = 24 * time.Hour
 
 type Depper struct {
 	// Place onto which jobs are placed for Libraries.io to further examine a package manager's package
-	pipeline           *publishers.Pipeline
-	signalHandler      chan os.Signal
-	streamingIngestors []*ingestors.StreamingIngestor
+	pipeline      *publishers.Pipeline
+	signalHandler chan os.Signal
 }
 
 func waitForExitSignal(signalHandler chan os.Signal) os.Signal {
@@ -132,21 +130,6 @@ func (depper *Depper) registerIngestor(ingestor ingestors.PollingIngestor) {
 
 	// For now we'll run once upon registration
 	ingestAndPublish()
-}
-
-func (depper *Depper) registerIngestorStream(ingestor ingestors.StreamingIngestor) {
-	depper.streamingIngestors = append(depper.streamingIngestors, &ingestor)
-
-	// Unbuffered channel so that the StreamingIngestor will block while pulling
-	// next updates until Publish() has grabbed the last one.
-	packageVersions := make(chan data.PackageVersion)
-
-	go ingestor.Ingest(packageVersions)
-	go func() {
-		for packageVersion := range packageVersions {
-			depper.pipeline.Publish(defaultTTL, packageVersion)
-		}
-	}()
 }
 
 func setupLogger() {

--- a/publishers/logging_publisher.go
+++ b/publishers/logging_publisher.go
@@ -9,13 +9,20 @@ import (
 type LoggingPublisher struct{}
 
 func (publisher *LoggingPublisher) Publish(packageVersion data.PackageVersion) {
+	field := log.Fields{
+		"platform":     packageVersion.Platform,
+		"name":         packageVersion.Name,
+		"version":      packageVersion.Version,
+		"created":      packageVersion.CreatedAt,
+		"discoveryLag": packageVersion.DiscoveryLag.Milliseconds(),
+		"sequence":     packageVersion.Sequence,
+	}
+
+	if packageVersion.Sequence != "" {
+		field["sequence"] = packageVersion.Sequence
+	}
+
 	log.
-		WithFields(log.Fields{
-			"platform":     packageVersion.Platform,
-			"name":         packageVersion.Name,
-			"version":      packageVersion.Version,
-			"created":      packageVersion.CreatedAt,
-			"discoveryLag": packageVersion.DiscoveryLag.Milliseconds(),
-		}).
+		WithFields(field).
 		Info("Depper publish")
 }


### PR DESCRIPTION
The NPM replica is being converted from a CouchDB streaming API to a REST pagination API: 

* [Announcement](https://github.blog/changelog/2025-02-27-changes-and-deprecation-notice-for-npm-replication-apis/)
* [NPM changes discussion](https://github.com/orgs/community/discussions/152515)

The `include_docs=true` parameter that gave us access to version and timestamps is being removed, so unfortunately we will only get Platform/Name for changes. 

NPM recommends people to use `https://registry.npmjs.org/<package-name>` to fetch the package metadata now, but Libraries [already fetches that URL](https://github.com/librariesio/libraries.io/blob/main/app/models/package_manager/npm.rb#L44-L46) so it wouldn't help much to do that here.

